### PR TITLE
Implement recency-based sorting for conversation list in sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# Agent Guidelines
+
+## Commands
+
+- `bun run src/ui/index.tsx` - Start the TUI application
+- `bun test` - Run all tests
+- `bun test <file>` - Run a single test file (e.g., `bun test src/core/MessageStorage.test.ts`)
+- `bun install` - Install dependencies
+- `bun run <script>` - Run npm scripts
+
+## Bun Runtime Rules (from .cursor/rules/)
+
+**Default to Bun, not Node.js:**
+- Use `bun <file>` instead of `node` or `ts-node`
+- Use `bun install` instead of `npm/pnpm/yarn install`
+- Use `bun build` instead of `webpack`/`esbuild`
+- Bun automatically loads `.env`, never use dotenv
+
+**API Preferences:**
+- `bun:sqlite` for SQLite, NOT `better-sqlite3`
+- `Bun.file` instead of `node:fs` readFile/writeFile
+- `Bun.$` instead of execa
+- `Bun.serve()` for servers with WebSockets/routes, NOT express
+- `WebSocket` is built-in, NOT `ws`
+- `Bun.redis` for Redis, NOT `ioredis`
+
+## Code Style
+
+**Imports:**
+- Use `node:` prefix for built-in modules: `import { mkdir } from "node:fs/promises"`
+- Always include file extensions: `import { foo } from "./bar.ts"` or `import Component from "./Component.tsx"`
+- Group imports: external libs, internal modules, then types
+
+**Naming Conventions:**
+- Classes/Components: `PascalCase` (e.g., `MessageStorage`, `ChatArea`)
+- Functions/Variables: `camelCase` (e.g., `getMessages`, `normalizeNumber`)
+- Private methods: prefix with `_` (e.g., `_saveMessage`)
+- Constants: `UPPER_SNAKE_CASE` (e.g., `DEFAULT_SIGNAL_CLI_PATH`)
+- Type aliases: `PascalCase` (e.g., `ChatMessage`, `LinkStatus`)
+
+**React/Ink TUI:**
+- Use functional components with hooks only
+- React 19 - no need for `import React`
+- Destructure props directly in function signature
+- Use `useState`, `useEffect`, `useRef` from `react`
+- Use Ink components: `Box`, `Text`, `useApp`, `useInput`
+
+**TypeScript:**
+- Strict mode enabled
+- Use type imports: `import type { Foo } from "./bar"`
+- Union literals with `as const` for narrow types
+- JSDoc comments on all public functions
+
+**Testing:**
+- Use `bun:test`: `import { test, expect, describe, beforeEach, afterAll } from "bun:test"`
+- Test files named `*.test.ts` next to source files
+- Use `beforeEach`/`afterAll` for setup/teardown
+- Clean up test databases after each test
+
+**Error Handling:**
+- Type check errors: `if (error instanceof Error)`
+- Graceful shutdown with refs to track intentional stops
+- Wrap subprocess operations in try-catch
+- Emit error events for async operations
+
+**Database (bun:sqlite):**
+- Parameterized queries with `$param` syntax
+- Use prepared statements with `query().run()`
+- Handle missing columns gracefully with try-catch
+
+**Signal-CLI Integration:**
+- JSON-RPC over stdin/stdout via `Bun.spawn()`
+- Manage pending requests with timeout handling
+- Buffer parsing for multi-line JSON responses
+- Emit events for: `message`, `sync`, `error`, `close`

--- a/src/core/MessageStorage.test.ts
+++ b/src/core/MessageStorage.test.ts
@@ -98,4 +98,130 @@ describe("MessageStorage", () => {
         storage.close();
         await unlink(dbPath);
     });
+
+    test("getConversationLastMessage should return null for conversation with no messages", async () => {
+        const result = storage.getConversationLastMessage("+9999999999");
+        expect(result).toBeNull();
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("getConversationLastMessage should return the most recent message", async () => {
+        const conversationId = "+1234567890";
+        const olderTimestamp = 1000000;
+        const newerTimestamp = 2000000;
+
+        storage.addMessage({
+            id: "msg1",
+            sender: "+1234567890",
+            content: "First message",
+            timestamp: olderTimestamp,
+            isOutgoing: false
+        }, conversationId);
+
+        storage.addMessage({
+            id: "msg2",
+            sender: "+1234567890",
+            content: "Second message",
+            timestamp: newerTimestamp,
+            isOutgoing: true
+        }, conversationId);
+
+        const result = storage.getConversationLastMessage(conversationId);
+        expect(result).not.toBeNull();
+        expect(result!.timestamp).toBe(newerTimestamp);
+        expect(result!.content).toBe("Second message");
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("getAllConversationMetadata should return empty map when no messages exist", async () => {
+        const metadata = storage.getAllConversationMetadata();
+        expect(metadata.size).toBe(0);
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("getAllConversationMetadata should return metadata for single conversation", async () => {
+        const conversationId = "+1234567890";
+        const timestamp = Date.now();
+
+        storage.addMessage({
+            id: "msg1",
+            sender: conversationId,
+            content: "Test message",
+            timestamp: timestamp,
+            isOutgoing: false
+        }, conversationId);
+
+        const metadata = storage.getAllConversationMetadata();
+        expect(metadata.size).toBe(1);
+
+        const meta = metadata.get(conversationId);
+        expect(meta).toBeDefined();
+        expect(meta!.timestamp).toBe(timestamp);
+        expect(meta!.content).toBe("Test message");
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("getAllConversationMetadata should return metadata for multiple conversations", async () => {
+        const conv1 = "+1234567890";
+        const conv2 = "+0987654321";
+        const timestamp1 = Date.now();
+        const timestamp2 = timestamp1 + 1000;
+
+        storage.addMessage({
+            id: "msg1",
+            sender: conv1,
+            content: "Message from conv1",
+            timestamp: timestamp1,
+            isOutgoing: false
+        }, conv1);
+
+        storage.addMessage({
+            id: "msg2",
+            sender: conv2,
+            content: "Message from conv2",
+            timestamp: timestamp2,
+            isOutgoing: true
+        }, conv2);
+
+        const metadata = storage.getAllConversationMetadata();
+        expect(metadata.size).toBe(2);
+
+        expect(metadata.get(conv1)!.timestamp).toBe(timestamp1);
+        expect(metadata.get(conv2)!.timestamp).toBe(timestamp2);
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("getAllConversationMetadata should use MAX timestamp for multiple messages per conversation", async () => {
+        const conversationId = "+1234567890";
+        const timestamps = [1000, 5000, 3000, 7000];
+
+        timestamps.forEach((ts, i) => {
+            storage.addMessage({
+                id: `msg${i}`,
+                sender: conversationId,
+                content: `Message ${i}`,
+                timestamp: ts,
+                isOutgoing: i % 2 === 0
+            }, conversationId);
+        });
+
+        const metadata = storage.getAllConversationMetadata();
+        const meta = metadata.get(conversationId);
+
+        expect(meta!.timestamp).toBe(7000);
+        expect(meta!.content).toBe("Message 3");
+
+        storage.close();
+        await unlink(dbPath);
+    });
 });

--- a/src/ui/components/Layout.tsx
+++ b/src/ui/components/Layout.tsx
@@ -47,13 +47,14 @@ export default function Layout({
   // Normal chat layout with sidebar
   return (
     <Box flexDirection="row" width="100%" height="100%">
-      <Sidebar 
-        currentView={currentView} 
+      <Sidebar
+        currentView={currentView}
         accounts={accounts}
         onLinkNewDevice={onLinkNewDevice}
         client={client}
         selectedConversation={selectedConversation}
         onSelectConversation={onSelectConversation}
+        storage={storage}
       />
       <ChatArea 
         currentView={currentView} 

--- a/src/utils/sortByRecency.test.ts
+++ b/src/utils/sortByRecency.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import { sortByRecency } from "./sortByRecency";
+import type { Conversation } from "../types/types.ts";
+
+describe("sortByRecency", () => {
+  test("sorts conversations with messages by most recent timestamp (descending)", () => {
+    const now = Date.now();
+    const conv1: Conversation = {
+      id: "1",
+      type: "contact",
+      displayName: "Alice",
+      lastMessageTime: now - 1000,
+      lastMessage: "Hello"
+    };
+    const conv2: Conversation = {
+      id: "2",
+      type: "contact",
+      displayName: "Bob",
+      lastMessageTime: now,
+      lastMessage: "Hi"
+    };
+    const conv3: Conversation = {
+      id: "3",
+      type: "contact",
+      displayName: "Charlie",
+      lastMessageTime: now - 5000,
+      lastMessage: "Hey"
+    };
+
+    const sorted = sortByRecency([conv1, conv2, conv3]);
+    expect(sorted).toEqual([conv2, conv1, conv3]);
+  });
+
+  test("places conversations without messages after those with messages", () => {
+    const now = Date.now();
+    const conv1: Conversation = {
+      id: "1",
+      type: "contact",
+      displayName: "Alice",
+      lastMessageTime: now,
+      lastMessage: "Hello"
+    };
+    const conv2: Conversation = {
+      id: "2",
+      type: "contact",
+      displayName: "Bob"
+    };
+    const conv3: Conversation = {
+      id: "3",
+      type: "contact",
+      displayName: "Charlie",
+      lastMessageTime: now - 1000,
+      lastMessage: "Hey"
+    };
+    const conv4: Conversation = {
+      id: "4",
+      type: "contact",
+      displayName: "David"
+    };
+
+    const sorted = sortByRecency([conv1, conv2, conv3, conv4]);
+    expect(sorted[0]!.id).toBe("1");
+    expect(sorted[1]!.id).toBe("3");
+    expect(sorted[2]!.id).toBe("2");
+    expect(sorted[3]!.id).toBe("4");
+  });
+
+  test("sorts no-message conversations alphabetically", () => {
+    const conv1: Conversation = {
+      id: "1",
+      type: "contact",
+      displayName: "Charlie"
+    };
+    const conv2: Conversation = {
+      id: "2",
+      type: "contact",
+      displayName: "Alice"
+    };
+    const conv3: Conversation = {
+      id: "3",
+      type: "contact",
+      displayName: "Bob"
+    };
+
+    const sorted = sortByRecency([conv1, conv2, conv3]);
+    expect(sorted[0]!.displayName).toBe("Alice");
+    expect(sorted[1]!.displayName).toBe("Bob");
+    expect(sorted[2]!.displayName).toBe("Charlie");
+  });
+
+  test("handles single conversation", () => {
+    const conv: Conversation = {
+      id: "1",
+      type: "contact",
+      displayName: "Alice",
+      lastMessageTime: Date.now(),
+      lastMessage: "Hello"
+    };
+
+    const sorted = sortByRecency([conv]);
+    expect(sorted).toEqual([conv]);
+  });
+
+  test("handles empty array", () => {
+    const sorted = sortByRecency([]);
+    expect(sorted).toEqual([]);
+  });
+
+  test("handles all conversations with messages", () => {
+    const now = Date.now();
+    const conv1: Conversation = {
+      id: "1",
+      type: "contact",
+      displayName: "Zoe",
+      lastMessageTime: now - 3000,
+      lastMessage: "A"
+    };
+    const conv2: Conversation = {
+      id: "2",
+      type: "contact",
+      displayName: "Adam",
+      lastMessageTime: now,
+      lastMessage: "B"
+    };
+    const conv3: Conversation = {
+      id: "3",
+      type: "contact",
+      displayName: "Bob",
+      lastMessageTime: now - 1000,
+      lastMessage: "C"
+    };
+
+    const sorted = sortByRecency([conv1, conv2, conv3]);
+    expect(sorted[0]!.id).toBe("2");
+    expect(sorted[1]!.id).toBe("3");
+    expect(sorted[2]!.id).toBe("1");
+  });
+
+  test("handles all conversations without messages", () => {
+    const conv1: Conversation = {
+      id: "1",
+      type: "contact",
+      displayName: "Charlie"
+    };
+    const conv2: Conversation = {
+      id: "2",
+      type: "contact",
+      displayName: "Alice"
+    };
+    const conv3: Conversation = {
+      id: "3",
+      type: "contact",
+      displayName: "Bob"
+    };
+
+    const sorted = sortByRecency([conv1, conv2, conv3]);
+    expect(sorted[0]!.displayName).toBe("Alice");
+    expect(sorted[1]!.displayName).toBe("Bob");
+    expect(sorted[2]!.displayName).toBe("Charlie");
+  });
+
+  test("handles both contacts and groups", () => {
+    const now = Date.now();
+    const contact: Conversation = {
+      id: "contact1",
+      type: "contact",
+      displayName: "Alice",
+      lastMessageTime: now,
+      lastMessage: "Hi"
+    };
+    const group1: Conversation = {
+      id: "group1",
+      type: "group",
+      displayName: "Work Chat",
+      lastMessageTime: now - 1000,
+      lastMessage: "Meeting"
+    };
+    const group2: Conversation = {
+      id: "group2",
+      type: "group",
+      displayName: "Family"
+    };
+
+    const sorted = sortByRecency([contact, group1, group2]);
+    expect(sorted[0]!.id).toBe("contact1");
+    expect(sorted[1]!.id).toBe("group1");
+    expect(sorted[2]!.id).toBe("group2");
+  });
+});

--- a/src/utils/sortByRecency.ts
+++ b/src/utils/sortByRecency.ts
@@ -1,0 +1,15 @@
+import type { Conversation } from "../types/types.ts";
+
+export function sortByRecency(convs: Conversation[]): Conversation[] {
+  return convs.sort((a, b) => {
+    const aTime = a.lastMessageTime || 0;
+    const bTime = b.lastMessageTime || 0;
+
+    if (aTime > 0 && bTime > 0) {
+      return bTime - aTime;
+    }
+    if (aTime > 0) return -1;
+    if (bTime > 0) return 1;
+    return a.displayName.localeCompare(b.displayName);
+  });
+}


### PR DESCRIPTION
 ## Summary
Implements recency-based sorting for the conversation list in the sidebar, replacing the previous alphabetical sorting. Conversations with messages are now sorted by most recent message (descending), while conversations without messages are sorted alphabetically and placed below active conversations.
 ## Changes
 ### Database Layer (`src/core/MessageStorage.ts`)
- Added `getConversationLastMessage(conversationId)` - Returns the most recent message timestamp and content for a single conversation
- Added `getAllConversationMetadata()` - Bulk query that retrieves last message metadata for all conversations using `GROUP BY` with `MAX(timestamp)` aggregation
 ### UI Components (`src/ui/components/Sidebar.tsx`)
- Updated to use `storage` prop for accessing conversation metadata
- Initial load now fetches metadata from storage and populates `lastMessageTime` and `lastMessage` on conversation objects
- Added real-time message event listener that reorders conversations when new messages arrive
- Selected conversation remains selected and visible after reordering
 ### Utility (`src/utils/sortByRecency.ts`)
- Extracted `sortByRecency()` function from Sidebar for better testability
- Sorts conversations by most recent message timestamp (descending)
- Conversations without messages are sorted alphabetically and placed after active conversations
 ### Layout (`src/ui/components/Layout.tsx`)
- Added `storage` prop pass-through to Sidebar component
 Tests (`src/core/MessageStorage.test.ts`, `src/utils/sortByRecency.test.ts`)
- Added 5 tests for `getConversationLastMessage()` and `getAllConversationMetadata()`
- Added 8 tests for `sortByRecency()` covering edge cases:
  - Sorting by timestamp (descending)
  - No-message conversations placed after active ones
  - Alphabetical sorting for no-message conversations
  - Empty arrays and single items
  - Mixed contacts and groups

 ## Behavior
- **On initial load**: Conversations are sorted by recency from database metadata
- **On new message**: The conversation moves to the top of the list immediately
- **No messages**: Sorted alphabetically and appear below conversations with messages
- **Both contacts and groups**: Sorted together by recency (no separation by type)
 
## Testing
All tests passing:
- 22 tests total across 3 files
- Database queries tested for correct aggregation
- Sorting logic tested for all edge cases
- Manual validation completed
 ## Performance
- Initial load uses a single `GROUP BY` query for all conversation metadata (indexed)
- Real-time updates are O(n) array operations (move to front + re-sort)
- No performance impact from extracting sorting logic to separate file
- Uses existing `idx_conversation_timestamp` index for efficient queries