### PR TITLE
Add configurable signal-cli path with auto-detection

### DIFF
--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -1,0 +1,91 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+
+export interface Config {
+  signalCliPath?: string;
+}
+
+const CONFIG_DIR = join(homedir(), ".signal-tui");
+const CONFIG_PATH = join(CONFIG_DIR, "config.json");
+
+const COMMON_SIGNAL_CLI_PATHS = [
+  "/usr/bin/signal-cli",
+  "/usr/local/bin/signal-cli",
+  "/opt/homebrew/bin/signal-cli",
+];
+
+/**
+ * Load configuration from ~/.signal-tui/config.json
+ * Returns empty object if file doesn't exist
+ */
+export function loadConfig(): Config {
+  try {
+    const file = Bun.file(CONFIG_PATH);
+    if (!existsSync(CONFIG_PATH)) {
+      return {};
+    }
+    // Use synchronous read for simplicity during startup
+    const content = require("node:fs").readFileSync(CONFIG_PATH, "utf-8");
+    return JSON.parse(content) as Config;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Find the signal-cli executable path
+ * Resolution order:
+ * 1. Config file signalCliPath
+ * 2. SIGNAL_CLI_PATH environment variable
+ * 3. First existing path from common locations
+ * 4. Returns null if not found
+ */
+export function findSignalCliPath(): string | null {
+  const config = loadConfig();
+
+  // 1. Check config file
+  if (config.signalCliPath) {
+    if (existsSync(config.signalCliPath)) {
+      return config.signalCliPath;
+    }
+    // Config specifies a path but it doesn't exist - still return it
+    // so the error message is clear about what was configured
+    return config.signalCliPath;
+  }
+
+  // 2. Check environment variable
+  const envPath = process.env.SIGNAL_CLI_PATH;
+  if (envPath) {
+    return envPath;
+  }
+
+  // 3. Try common paths
+  for (const path of COMMON_SIGNAL_CLI_PATHS) {
+    if (existsSync(path)) {
+      return path;
+    }
+  }
+
+  // 4. Not found
+  return null;
+}
+
+/**
+ * Get helpful instructions for configuring signal-cli path
+ */
+export function getConfigInstructions(): string {
+  const searchedPaths = COMMON_SIGNAL_CLI_PATHS.map((p) => `  - ${p}`).join("\n");
+
+  return `signal-cli not found!
+
+Searched the following locations:
+${searchedPaths}
+
+To configure, create ${CONFIG_PATH}:
+{
+  "signalCliPath": "/path/to/your/signal-cli"
+}
+
+Or set the SIGNAL_CLI_PATH environment variable.`;
+}

--- a/src/core/SignalClient.ts
+++ b/src/core/SignalClient.ts
@@ -14,7 +14,6 @@ import type {
   Group,
 } from "../types/types";
 
-const DEFAULT_SIGNAL_CLI_PATH = "/opt/homebrew/bin/signal-cli";
 const DEFAULT_REQUEST_TIMEOUT = 30000; // 30 seconds
 
 interface PendingRequest {
@@ -55,7 +54,7 @@ export class SignalClient extends EventEmitter {
 
   constructor(options: SignalClientOptions = {}) {
     super();
-    this.signalCliPath = options.signalCliPath ?? DEFAULT_SIGNAL_CLI_PATH;
+    this.signalCliPath = options.signalCliPath ?? "signal-cli";
     this.requestTimeout = options.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT;
     this.account = options.account;
   }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { Box, useApp, useInput } from "ink";
 import Layout from "./components/Layout.tsx";
 import { SignalClient } from "../core/SignalClient.ts";
+import { findSignalCliPath, getConfigInstructions } from "../core/Config.ts";
 import type { LinkStatus } from "./components/Onboarding.tsx";
 import type { Account, Conversation, SignalEnvelope, ChatMessage } from "../types/types.ts";
 import { appendFileSync } from "node:fs";
@@ -90,7 +91,17 @@ export default function App() {
         appendFileSync("debug.log", `[App] Mounting... storedReady=${storageReady}\n`);
     } catch(e) {}
 
+    // Find signal-cli path
+    const signalCliPath = findSignalCliPath();
+    if (!signalCliPath) {
+      setCurrentView("onboarding");
+      setLinkStatus("error");
+      setErrorMessage(getConfigInstructions());
+      return;
+    }
+
     const signalClient = new SignalClient({
+      signalCliPath,
       requestTimeout: 120000, // 2 minutes for linking timeout
     });
 


### PR DESCRIPTION
## Summary
- Create Config module (`src/core/Config.ts`) to handle signal-cli path resolution
- Resolution order: config file → `SIGNAL_CLI_PATH` env var → auto-detect common paths
- Auto-detect checks `/usr/bin/signal-cli`, `/usr/local/bin/signal-cli`, `/opt/homebrew/bin/signal-cli`
- Show helpful error with setup instructions if signal-cli is not found
- Remove hardcoded Mac-specific path from SignalClient

## Config File
Location: `~/.signal-tui/config.json`
```json
{
  "signalCliPath": "/usr/bin/signal-cli"
}
```

## Test plan
- [x] Test auto-detection on Linux: Remove config file, ensure signal-cli is at `/usr/bin/signal-cli`, run app - should start successfully
- [x] Test auto-detection on Mac: Remove config file, ensure signal-cli is at `/opt/homebrew/bin/signal-cli`, run app - should start successfully
- [x] Test config file override: Create `~/.signal-tui/config.json` with custom path, verify app uses that path
- [x] Test environment variable: Set `SIGNAL_CLI_PATH=/custom/path`, verify app uses that path
- [x] Test helpful error: Remove signal-cli from all common paths and config, verify helpful error message is displayed

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)