### PR TITLE
feat: add media support and UI/UX overhaul

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,4 +72,10 @@
 - JSON-RPC over stdin/stdout via `Bun.spawn()`
 - Manage pending requests with timeout handling
 - Buffer parsing for multi-line JSON responses
-- Emit events for: `message`, `sync`, `error`, `close`
+- Emit events for: `message`, `sync`, `receipt`, `error`, `close`
+- Receipt types: `READ`, `VIEWED`, `DELIVERY` — used for message status indicators
+
+**Media/Attachments:**
+- Images rendered as ASCII art via `ink-asciify-image` (stored in DB, not re-rendered)
+- Attachments stored in dedicated `attachments` table with download status tracking
+- MIME type utilities in `src/utils/mime.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,10 @@ Signal-TUI is a Terminal User Interface for Signal Messenger, built with Bun, Re
 
 ```bash
 bun start                                    # Start the TUI application
-bun run src/ui/index.tsx                     # Alternative: run directly
+bun run typecheck                            # Run TypeScript type checking
 bun test                                     # Run all tests
 bun test src/core/MessageStorage.test.ts    # Run a single test file
-bun install                                  # Install dependencies
+bun run build                                # Build for current platform
 ```
 
 ## Architecture
@@ -27,12 +27,16 @@ src/
 ├── ui/                      # React/Ink TUI components
 │   ├── index.tsx            # Entry point
 │   ├── App.tsx              # Main app: initializes client/storage, manages app state (loading→onboarding→chat)
+│   ├── theme.ts             # Color theme constants
 │   └── components/
-│       ├── Sidebar.tsx      # Conversation list with recency sorting and keyboard navigation
-│       ├── ChatArea.tsx     # Message display with optimistic sending and history pagination
-│       └── Onboarding.tsx   # Device linking with QR code display
+│       ├── Sidebar.tsx      # Conversation list with search and keyboard navigation
+│       ├── ChatArea.tsx     # Message display with attachments and ASCII art images
+│       ├── MessageInput.tsx # Text input with /attach command support
+│       ├── Onboarding.tsx   # Device linking with QR code display
+│       ├── StatusBar.tsx    # Connection status and account info
+│       └── KeybindBar.tsx   # Context-aware keyboard shortcut hints
 ├── types/types.ts           # All TypeScript type definitions
-└── utils/                   # Phone normalization, conversation sorting
+└── utils/                   # Phone normalization, conversation sorting, MIME types, ASCII art
 ```
 
 **Key data flow:** signal-cli JSON-RPC → SignalClient events → App.tsx → MessageStorage (SQLite + event emission) → UI components listen to storage events
@@ -57,6 +61,19 @@ Default to Bun instead of Node.js:
 **Testing:** Use `bun:test`, files named `*.test.ts` next to source, clean up test databases in `afterAll`
 
 **Database:** Parameterized queries with `$param` syntax, prepared statements with `query().run()`
+
+## Signal-CLI Integration
+
+- JSON-RPC over stdin/stdout via `Bun.spawn()`
+- SignalClient emits events: `message`, `sync`, `receipt`, `typing`, `error`, `close`, `ready`, `linkSuccess`
+- Receipt types: `DELIVERY`, `READ`, `VIEWED` — used for message status indicators (◯ → ✓ → ✓✓)
+
+## Media/Attachments
+
+- Images rendered as ASCII art via `ink-asciify-image`, stored in database (not re-rendered)
+- `/attach <filepath> [message]` command to send files
+- Attachments table tracks download status: `pending` → `downloading` → `completed`/`failed`
+- MIME type utilities in `src/utils/mime.ts`
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,55 +1,108 @@
-# signal-tui
+# 📱 Signal-TUI
 
-A Terminal User Interface (TUI) for Signal, built with [Bun](https://bun.sh) and [Ink](https://github.com/vadimdemedes/ink).
+[![Bun](https://img.shields.io/badge/runtime-Bun-f9f1e1?logo=bun)](https://bun.sh)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue?logo=typescript)](https://www.typescriptlang.org/)
+[![React](https://img.shields.io/badge/React-19-61dafb?logo=react)](https://react.dev/)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-## Prerequisites
+> A beautiful Terminal User Interface for Signal Messenger, built with [Bun](https://bun.sh), [React](https://react.dev/), and [Ink](https://github.com/vadimdemedes/ink).
+
+---
+
+## ✨ Features
+
+- 💬 **Real-time Messaging** — Send and receive messages instantly via signal-cli
+- 🖼️ **Media Support** — View images as ASCII art, send attachments with the `/attach` command
+- 🎤 **Voice Messages** — See voice message duration and metadata
+- ✅ **Message Status** — Track message delivery with status indicators (◯ sent, ✓ delivered, ✓✓ read)
+- ⌨️ **Vim-style Navigation** — Navigate with `j`/`k`, jump with `G`/`gg`
+- 🔍 **Quick Search** — Filter conversations with `/` in the sidebar
+- 🎨 **Beautiful UI** — Themed interface with focus highlighting and status bar
+- 📋 **Context-aware Keybinds** — Dynamic keybind bar shows available shortcuts
+
+---
+
+## 📋 Prerequisites
 
 - **[Bun](https://bun.sh)** (v1.0.0 or later)
-- **[signal-cli](https://github.com/AsamK/signal-cli)**: This project relies on `signal-cli` for Signal communication.
-  - The app will auto-detect `signal-cli` at common paths (`/usr/bin/signal-cli`, `/usr/local/bin/signal-cli`, `/opt/homebrew/bin/signal-cli`)
-  - You can also set a custom path via the `SIGNAL_CLI_PATH` environment variable or config file (see [Configuration](#configuration))
+- **[signal-cli](https://github.com/AsamK/signal-cli)** — Required for Signal communication
+  - Auto-detected at common paths: `/usr/bin/signal-cli`, `/usr/local/bin/signal-cli`, `/opt/homebrew/bin/signal-cli`
+  - Or set a custom path via `SIGNAL_CLI_PATH` env variable or [config file](#%EF%B8%8F-configuration)
 
-## Installation
+---
 
-1. Clone the repository:
+## 🚀 Installation
 
-   ```bash
-   git clone https://github.com/allisonmahmood/Signal-TUI.git
-   cd Signal-TUI
-   ```
+```bash
+# Clone the repository
+git clone https://github.com/allisonmahmood/Signal-TUI.git
+cd Signal-TUI
 
-2. Install dependencies:
-   ```bash
-   bun install
-   ```
+# Install dependencies
+bun install
+```
 
-## Usage
+---
 
-To start the application:
+## 💻 Usage
+
+### Starting the App
 
 ```bash
 bun start
 ```
 
-### Controls
+On first launch, you'll be guided through device linking with a QR code.
 
-| Context     | Key        | Action                    |
-| :---------- | :--------- | :------------------------ |
-| **Global**  | `Ctrl+C`   | Quit Application          |
-| **Global**  | `Ctrl+L`   | Link New Device           |
-| **Global**  | `Tab`      | Cycle Focus (Sidebar → Chat → Input) |
-| **Sidebar** | `↑` / `↓`  | Navigate Conversations    |
-| **Sidebar** | `Enter`    | Select Conversation       |
-| **Chat**    | `PageUp`   | Scroll History Up         |
-| **Chat**    | `PageDown` | Scroll History Down       |
-| **Input**   | `Enter`    | Send Message              |
-| **Input**   | `Escape`   | Exit Input Mode           |
-| **Input**   | `Ctrl+A`   | Move Cursor to Start      |
-| **Input**   | `Ctrl+E`   | Move Cursor to End        |
-| **Input**   | `Ctrl+U`   | Clear Line                |
-| **Input**   | `Ctrl+W`   | Delete Word Backward      |
+### ⌨️ Keyboard Controls
 
-## Configuration
+| Context       | Key              | Action                          |
+| :------------ | :--------------- | :------------------------------ |
+| **Global**    | `Ctrl+C`         | Quit application                |
+| **Global**    | `Ctrl+L`         | Link new device                 |
+| **Global**    | `Tab`            | Cycle focus (Sidebar → Chat → Input) |
+| **Sidebar**   | `↑` / `k`        | Navigate up                     |
+| **Sidebar**   | `↓` / `j`        | Navigate down                   |
+| **Sidebar**   | `Enter`          | Select conversation             |
+| **Sidebar**   | `/`              | Search/filter conversations     |
+| **Sidebar**   | `Esc`            | Exit search mode                |
+| **Chat**      | `↑` / `k`        | Scroll up                       |
+| **Chat**      | `↓` / `j`        | Scroll down                     |
+| **Chat**      | `PageUp`         | Scroll up one page              |
+| **Chat**      | `PageDown`       | Scroll down one page            |
+| **Chat**      | `G`              | Jump to bottom (newest)         |
+| **Chat**      | `gg`             | Jump to top (oldest)            |
+| **Input**     | `Enter`          | Send message                    |
+| **Input**     | `Escape`         | Exit input mode                 |
+| **Input**     | `Ctrl+A`         | Move cursor to start            |
+| **Input**     | `Ctrl+E`         | Move cursor to end              |
+| **Input**     | `Ctrl+U`         | Clear line                      |
+| **Input**     | `Ctrl+W`         | Delete word backward            |
+
+### 📎 Sending Attachments
+
+Use the `/attach` command to send files:
+
+```
+/attach <filepath> [optional message]
+```
+
+**Examples:**
+```bash
+/attach ~/photos/image.png                    # Send an image
+/attach "/path/with spaces/file.pdf"          # Paths with spaces (use quotes)
+/attach ~/document.pdf Here's the file!       # Include a message
+```
+
+**Features:**
+- ✓ Real-time file validation (green ✓ = exists, red ✗ = not found)
+- ✓ Supports images, documents, audio, and any file type
+- ✓ Images are displayed as ASCII art in the chat
+- ✓ Voice messages show duration
+
+---
+
+## ⚙️ Configuration
 
 Configuration is stored in `~/.signal-tui/config.json`. The database is automatically created on first run.
 
@@ -66,7 +119,52 @@ The app looks for `signal-cli` in this order:
 2. `SIGNAL_CLI_PATH` environment variable
 3. Auto-detect at common paths: `/usr/bin/signal-cli`, `/usr/local/bin/signal-cli`, `/opt/homebrew/bin/signal-cli`
 
-## Troubleshooting
+---
 
-- **`signal-cli` not found**: The app will show a helpful error with setup instructions. You can verify signal-cli is installed by running `signal-cli --version`. If it's installed at a non-standard path, set it in the config file or via `SIGNAL_CLI_PATH` environment variable.
-- **Database issues**: If you encounter local database errors, try deleting `~/.signal-tui/db.sqlite` to reset the message cache.
+## 🏗️ Architecture
+
+```
+src/
+├── core/                    # Core business logic
+│   ├── SignalClient.ts      # JSON-RPC wrapper for signal-cli
+│   ├── MessageStorage.ts    # SQLite persistence with EventEmitter
+│   └── Config.ts            # Configuration management
+├── ui/                      # React/Ink components
+│   ├── App.tsx              # Main app state management
+│   └── components/
+│       ├── Sidebar.tsx      # Conversation list with search
+│       ├── ChatArea.tsx     # Message display with attachments
+│       ├── MessageInput.tsx # Input with /attach support
+│       ├── StatusBar.tsx    # Connection status & info
+│       └── KeybindBar.tsx   # Context-aware shortcuts
+├── types/                   # TypeScript definitions
+└── utils/                   # Helpers (formatting, MIME types, ASCII art)
+```
+
+**Data Flow:** `signal-cli` → `SignalClient` (events) → `App.tsx` → `MessageStorage` (SQLite) → UI components
+
+---
+
+## 🔧 Troubleshooting
+
+| Issue | Solution |
+| :---- | :------- |
+| **signal-cli not found** | Verify with `signal-cli --version`. Set path in config or `SIGNAL_CLI_PATH` env |
+| **Database errors** | Delete `~/.signal-tui/db.sqlite` to reset the message cache |
+| **QR code not scanning** | Ensure your terminal supports Unicode and is sized appropriately |
+| **Messages not loading** | Check signal-cli is running and linked to your account |
+
+---
+
+## 🛠️ Built With
+
+- **[Bun](https://bun.sh)** — Fast JavaScript runtime with native SQLite
+- **[React](https://react.dev/)** — UI component library (v19)
+- **[Ink](https://github.com/vadimdemedes/ink)** — React for CLIs
+- **[signal-cli](https://github.com/AsamK/signal-cli)** — Signal Messenger CLI
+
+---
+
+## 📄 License
+
+MIT

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "ink-text-input": "^6.0.0",
         "qrcode-terminal": "^0.12.0",
         "react": "^19.2.3",
+        "terminal-image": "^4.2.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -23,11 +24,99 @@
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-mkOh+Wwawzuf5wa30bvc4nA+Qb6DIrGWgBhRR/Pw4T9nsgYait8izvXkNyU78D6Wcu3Z+KUdwCmLCxlWjEotYA=="],
 
+    "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
+
+    "@jimp/bmp": ["@jimp/bmp@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "bmp-js": "^0.1.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A=="],
+
+    "@jimp/core": ["@jimp/core@1.6.0", "", { "dependencies": { "@jimp/file-ops": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "await-to-js": "^3.0.0", "exif-parser": "^0.1.12", "file-type": "^16.0.0", "mime": "3" } }, "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w=="],
+
+    "@jimp/custom": ["@jimp/custom@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/core": "^0.14.0" } }, "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA=="],
+
+    "@jimp/diff": ["@jimp/diff@1.6.0", "", { "dependencies": { "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "pixelmatch": "^5.3.0" } }, "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw=="],
+
+    "@jimp/file-ops": ["@jimp/file-ops@1.6.0", "", {}, "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ=="],
+
+    "@jimp/gif": ["@jimp/gif@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "gifwrap": "^0.9.2", "omggif": "^1.0.9" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg=="],
+
+    "@jimp/jpeg": ["@jimp/jpeg@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "jpeg-js": "^0.4.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ=="],
+
+    "@jimp/js-bmp": ["@jimp/js-bmp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "bmp-ts": "^1.0.9" } }, "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw=="],
+
+    "@jimp/js-gif": ["@jimp/js-gif@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "gifwrap": "^0.10.1", "omggif": "^1.0.10" } }, "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g=="],
+
+    "@jimp/js-jpeg": ["@jimp/js-jpeg@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "jpeg-js": "^0.4.4" } }, "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA=="],
+
+    "@jimp/js-png": ["@jimp/js-png@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "pngjs": "^7.0.0" } }, "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg=="],
+
+    "@jimp/js-tiff": ["@jimp/js-tiff@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "utif2": "^4.1.0" } }, "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw=="],
+
+    "@jimp/plugin-blit": ["@jimp/plugin-blit@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA=="],
+
+    "@jimp/plugin-blur": ["@jimp/plugin-blur@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw=="],
+
+    "@jimp/plugin-circle": ["@jimp/plugin-circle@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw=="],
+
+    "@jimp/plugin-color": ["@jimp/plugin-color@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "tinycolor2": "^1.6.0", "zod": "^3.23.8" } }, "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA=="],
+
+    "@jimp/plugin-contain": ["@jimp/plugin-contain@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ=="],
+
+    "@jimp/plugin-cover": ["@jimp/plugin-cover@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA=="],
+
+    "@jimp/plugin-crop": ["@jimp/plugin-crop@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang=="],
+
+    "@jimp/plugin-displace": ["@jimp/plugin-displace@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q=="],
+
+    "@jimp/plugin-dither": ["@jimp/plugin-dither@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0" } }, "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ=="],
+
+    "@jimp/plugin-fisheye": ["@jimp/plugin-fisheye@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA=="],
+
+    "@jimp/plugin-flip": ["@jimp/plugin-flip@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg=="],
+
+    "@jimp/plugin-gaussian": ["@jimp/plugin-gaussian@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ=="],
+
+    "@jimp/plugin-hash": ["@jimp/plugin-hash@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "any-base": "^1.1.0" } }, "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q=="],
+
+    "@jimp/plugin-invert": ["@jimp/plugin-invert@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg=="],
+
+    "@jimp/plugin-mask": ["@jimp/plugin-mask@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA=="],
+
+    "@jimp/plugin-normalize": ["@jimp/plugin-normalize@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ=="],
+
+    "@jimp/plugin-print": ["@jimp/plugin-print@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/types": "1.6.0", "parse-bmfont-ascii": "^1.0.6", "parse-bmfont-binary": "^1.0.6", "parse-bmfont-xml": "^1.1.6", "simple-xml-to-json": "^1.2.2", "zod": "^3.23.8" } }, "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A=="],
+
+    "@jimp/plugin-quantize": ["@jimp/plugin-quantize@1.6.0", "", { "dependencies": { "image-q": "^4.0.0", "zod": "^3.23.8" } }, "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg=="],
+
+    "@jimp/plugin-resize": ["@jimp/plugin-resize@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA=="],
+
+    "@jimp/plugin-rotate": ["@jimp/plugin-rotate@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw=="],
+
+    "@jimp/plugin-scale": ["@jimp/plugin-scale@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-resize": ">=0.3.5" } }, "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw=="],
+
+    "@jimp/plugin-shadow": ["@jimp/plugin-shadow@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-blur": ">=0.3.5", "@jimp/plugin-resize": ">=0.3.5" } }, "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ=="],
+
+    "@jimp/plugin-threshold": ["@jimp/plugin-threshold@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w=="],
+
+    "@jimp/plugins": ["@jimp/plugins@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/plugin-blit": "^0.14.0", "@jimp/plugin-blur": "^0.14.0", "@jimp/plugin-circle": "^0.14.0", "@jimp/plugin-color": "^0.14.0", "@jimp/plugin-contain": "^0.14.0", "@jimp/plugin-cover": "^0.14.0", "@jimp/plugin-crop": "^0.14.0", "@jimp/plugin-displace": "^0.14.0", "@jimp/plugin-dither": "^0.14.0", "@jimp/plugin-fisheye": "^0.14.0", "@jimp/plugin-flip": "^0.14.0", "@jimp/plugin-gaussian": "^0.14.0", "@jimp/plugin-invert": "^0.14.0", "@jimp/plugin-mask": "^0.14.0", "@jimp/plugin-normalize": "^0.14.0", "@jimp/plugin-print": "^0.14.0", "@jimp/plugin-resize": "^0.14.0", "@jimp/plugin-rotate": "^0.14.0", "@jimp/plugin-scale": "^0.14.0", "@jimp/plugin-shadow": "^0.14.0", "@jimp/plugin-threshold": "^0.14.0", "timm": "^1.6.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw=="],
+
+    "@jimp/png": ["@jimp/png@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "pngjs": "^3.3.3" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA=="],
+
+    "@jimp/tiff": ["@jimp/tiff@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "utif": "^2.0.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw=="],
+
+    "@jimp/types": ["@jimp/types@1.6.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg=="],
+
+    "@jimp/utils": ["@jimp/utils@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "tinycolor2": "^1.6.0" } }, "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
     "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
 
     "@types/node": ["@types/node@25.0.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-czWPzKIAXucn9PtsttxmumiQ9N0ok9FrBwgRWrwmVLlp86BrMExzvXRLFYRJ+Ex3g6yqj+KuaxfX1JTgV2lpfg=="],
 
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
+
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
     "ansi-escapes": ["ansi-escapes@7.2.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
 
@@ -35,9 +124,29 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
+
+    "app-path": ["app-path@4.0.0", "", { "dependencies": { "execa": "^5.0.0" } }, "sha512-mgBO9PZJ3MpbKbwFTljTi36ZKBvG5X/fkVR1F85ANsVcVllEb+C0LGNdJfGUm84GpC4xxgN6HFkmkMU8VEO4mA=="],
+
+    "array-range": ["array-range@1.0.1", "", {}, "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA=="],
+
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
+    "await-to-js": ["await-to-js@3.0.0", "", {}, "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bmp-js": ["bmp-js@0.1.0", "", {}, "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="],
+
+    "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "buffer-equal": ["buffer-equal@0.0.1", "", {}, "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="],
+
     "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
+
+    "centra": ["centra@2.7.0", "", { "dependencies": { "follow-redirects": "^1.15.6" } }, "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -51,7 +160,17 @@
 
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "cycled": ["cycled@1.2.0", "", {}, "sha512-/BOOCEohSBflVHHtY/wUc1F6YDYPqyVs/A837gDoq4H1pm72nU/yChyGt91V4ML+MbbAmHs8uo2l1yJkkTIUdg=="],
+
+    "decode-gif": ["decode-gif@1.0.1", "", { "dependencies": { "array-range": "^1.0.1", "omggif": "^1.0.10" } }, "sha512-L0MT527mwlkil9TiN1xwnJXzUxCup55bUT91CPmQlc9zYejXJ8xp17d5EVnwM80JOIGImBUk1ptJQ+hDihyzwg=="],
+
+    "delay": ["delay@4.4.1", "", {}, "sha512-aL3AhqtfhOlT/3ai6sWXeqwnw63ATNpnUiN4HL7x9q+My5QtHlO3OIkasmug9LKzpheLdmUKGRKnYXYAS7FQkQ=="],
+
+    "dom-walk": ["dom-walk@0.1.2", "", {}, "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -61,7 +180,33 @@
 
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
+    "exif-parser": ["exif-parser@0.1.12", "", {}, "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="],
+
+    "file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
+
+    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
+    "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
+
+    "global": ["global@4.4.0", "", { "dependencies": { "min-document": "^2.19.0", "process": "^0.11.10" } }, "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w=="],
+
+    "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "image-dimensions": ["image-dimensions@2.5.0", "", { "bin": { "image-dimensions": "cli.js" } }, "sha512-CKZPHjAEtSg9lBV9eER0bhNn/yrY7cFEQEhkwjLhqLY+Na8lcP1pEyWsaGMGc8t2qbKWA/tuqbhFQpOKGN72Yw=="],
+
+    "image-q": ["image-q@4.0.0", "", { "dependencies": { "@types/node": "16.9.1" } }, "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw=="],
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
@@ -71,13 +216,69 @@
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
+    "is-function": ["is-function@1.0.2", "", {}, "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="],
+
     "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "iterm2-version": ["iterm2-version@5.0.0", "", { "dependencies": { "app-path": "^4.0.0", "plist": "^3.0.2" } }, "sha512-WdLXcMYvN3SXT6vEtuW78vnZs4pVWm2nBnb4VKjOPPXmdlR1xTHmBgqKacOzAe4RXOiY/V+0u/0zsU3LoGQoBg=="],
+
+    "jimp": ["jimp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/diff": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-gif": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-blur": "1.6.0", "@jimp/plugin-circle": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-contain": "1.6.0", "@jimp/plugin-cover": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-displace": "1.6.0", "@jimp/plugin-dither": "1.6.0", "@jimp/plugin-fisheye": "1.6.0", "@jimp/plugin-flip": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/plugin-mask": "1.6.0", "@jimp/plugin-print": "1.6.0", "@jimp/plugin-quantize": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/plugin-rotate": "1.6.0", "@jimp/plugin-threshold": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg=="],
+
+    "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
+
+    "load-bmfont": ["load-bmfont@1.4.2", "", { "dependencies": { "buffer-equal": "0.0.1", "mime": "^1.3.4", "parse-bmfont-ascii": "^1.0.3", "parse-bmfont-binary": "^1.0.5", "parse-bmfont-xml": "^1.1.4", "phin": "^3.7.1", "xhr": "^2.0.1", "xtend": "^4.0.0" } }, "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog=="],
+
+    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
+
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
+    "min-document": ["min-document@2.19.2", "", { "dependencies": { "dom-walk": "^0.1.0" } }, "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
+
+    "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "omggif": ["omggif@1.0.10", "", {}, "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="],
+
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parse-bmfont-ascii": ["parse-bmfont-ascii@1.0.6", "", {}, "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="],
+
+    "parse-bmfont-binary": ["parse-bmfont-binary@1.0.6", "", {}, "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="],
+
+    "parse-bmfont-xml": ["parse-bmfont-xml@1.1.6", "", { "dependencies": { "xml-parse-from-string": "^1.0.0", "xml2js": "^0.5.0" } }, "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA=="],
+
+    "parse-headers": ["parse-headers@2.0.6", "", {}, "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="],
+
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
+
+    "phin": ["phin@2.9.3", "", {}, "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="],
+
+    "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
+
+    "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
+
+    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "qrcode-terminal": ["qrcode-terminal@0.12.0", "", { "bin": { "qrcode-terminal": "./bin/qrcode-terminal.js" } }, "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="],
 
@@ -87,13 +288,31 @@
 
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
+    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "readable-web-to-node-stream": ["readable-web-to-node-stream@3.0.4", "", { "dependencies": { "readable-stream": "^4.7.0" } }, "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw=="],
+
+    "regenerator-runtime": ["regenerator-runtime@0.13.11", "", {}, "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="],
+
+    "render-gif": ["render-gif@2.0.4", "", { "dependencies": { "cycled": "^1.2.0", "decode-gif": "^1.0.1", "delay": "^4.3.0", "jimp": "^0.14.0" } }, "sha512-l5X7EwbEvdflnvVAzjL7njizwZN8ATqJ0rdaQ5WwMJ55vyWXIXIUE9Ut7W6hm+KE+HMYn5C0a+7t0B6JjGfxQA=="],
+
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "sax": ["sax@1.4.3", "", {}, "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "simple-xml-to-json": ["simple-xml-to-json@1.2.3", "", {}, "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA=="],
 
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
@@ -101,7 +320,25 @@
 
     "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
 
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
+    "strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
+
+    "supports-terminal-graphics": ["supports-terminal-graphics@0.1.0", "", {}, "sha512-+KdfozhS0Fw8y5Sghw8kkZNGT8nWYzJ1EzcoIvVjxhl+26TJTs26y02yfBgvc1jh5AS/c8jcI3xtahhR95KRyQ=="],
+
+    "term-img": ["term-img@7.1.0", "", { "dependencies": { "ansi-escapes": "^7.1.1", "iterm2-version": "^5.0.0" } }, "sha512-au++khgSDly2KXNhC6BOU3mLi2v+Dk5mChYKDcpB5xYwhlwqYQtj0z59dIqFEmr+w7ndZaNqurHapkGc6/hprQ=="],
+
+    "terminal-image": ["terminal-image@4.2.0", "", { "dependencies": { "chalk": "^5.6.2", "image-dimensions": "^2.5.0", "jimp": "^1.6.0", "log-update": "^6.1.0", "render-gif": "^2.0.4", "supports-terminal-graphics": "^0.1.0", "term-img": "^7.0.0" } }, "sha512-KlK1fgS2AjAg9wmC998ys1uHNXyRb61hgBrSMWK/n+uthMIPejkhYhVcZfQ1ikI99BhiqP6Exr4ISfiNStGdkg=="],
+
+    "timm": ["timm@1.7.1", "", {}, "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="],
+
+    "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
+
+    "token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
@@ -109,18 +346,156 @@
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "utif": ["utif@2.0.1", "", { "dependencies": { "pako": "^1.0.5" } }, "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg=="],
+
+    "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
+    "xhr": ["xhr@2.6.0", "", { "dependencies": { "global": "~4.4.0", "is-function": "^1.0.1", "parse-headers": "^2.0.0", "xtend": "^4.0.0" } }, "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA=="],
+
+    "xml-parse-from-string": ["xml-parse-from-string@1.0.1", "", {}, "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="],
+
+    "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
+
+    "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/bmp/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/custom/@jimp/core": ["@jimp/core@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "any-base": "^1.1.0", "buffer": "^5.2.0", "exif-parser": "^0.1.12", "file-type": "^9.0.0", "load-bmfont": "^1.3.1", "mkdirp": "^0.5.1", "phin": "^2.9.1", "pixelmatch": "^4.0.2", "tinycolor2": "^1.4.1" } }, "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w=="],
+
+    "@jimp/gif/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/gif/gifwrap": ["gifwrap@0.9.4", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ=="],
+
+    "@jimp/jpeg/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugin-gaussian/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugin-invert/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugin-normalize/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugin-scale/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugin-shadow/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-blit": ["@jimp/plugin-blit@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw=="],
+
+    "@jimp/plugins/@jimp/plugin-blur": ["@jimp/plugin-blur@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ=="],
+
+    "@jimp/plugins/@jimp/plugin-circle": ["@jimp/plugin-circle@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA=="],
+
+    "@jimp/plugins/@jimp/plugin-color": ["@jimp/plugin-color@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "tinycolor2": "^1.4.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ=="],
+
+    "@jimp/plugins/@jimp/plugin-contain": ["@jimp/plugin-contain@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-blit": ">=0.3.5", "@jimp/plugin-resize": ">=0.3.5", "@jimp/plugin-scale": ">=0.3.5" } }, "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg=="],
+
+    "@jimp/plugins/@jimp/plugin-cover": ["@jimp/plugin-cover@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-crop": ">=0.3.5", "@jimp/plugin-resize": ">=0.3.5", "@jimp/plugin-scale": ">=0.3.5" } }, "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ=="],
+
+    "@jimp/plugins/@jimp/plugin-crop": ["@jimp/plugin-crop@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug=="],
+
+    "@jimp/plugins/@jimp/plugin-displace": ["@jimp/plugin-displace@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg=="],
+
+    "@jimp/plugins/@jimp/plugin-dither": ["@jimp/plugin-dither@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ=="],
+
+    "@jimp/plugins/@jimp/plugin-fisheye": ["@jimp/plugin-fisheye@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg=="],
+
+    "@jimp/plugins/@jimp/plugin-flip": ["@jimp/plugin-flip@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-rotate": ">=0.3.5" } }, "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw=="],
+
+    "@jimp/plugins/@jimp/plugin-mask": ["@jimp/plugin-mask@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA=="],
+
+    "@jimp/plugins/@jimp/plugin-print": ["@jimp/plugin-print@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "load-bmfont": "^1.4.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-blit": ">=0.3.5" } }, "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ=="],
+
+    "@jimp/plugins/@jimp/plugin-resize": ["@jimp/plugin-resize@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ=="],
+
+    "@jimp/plugins/@jimp/plugin-rotate": ["@jimp/plugin-rotate@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-blit": ">=0.3.5", "@jimp/plugin-crop": ">=0.3.5", "@jimp/plugin-resize": ">=0.3.5" } }, "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q=="],
+
+    "@jimp/plugins/@jimp/plugin-threshold": ["@jimp/plugin-threshold@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-color": ">=0.8.0", "@jimp/plugin-resize": ">=0.8.0" } }, "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw=="],
+
+    "@jimp/png/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/png/pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
+
+    "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
+
     "ink/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "load-bmfont/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "load-bmfont/phin": ["phin@3.7.1", "", { "dependencies": { "centra": "^2.7.0" } }, "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ=="],
+
+    "log-update/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+
+    "readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "render-gif/jimp": ["jimp@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/custom": "^0.14.0", "@jimp/plugins": "^0.14.0", "@jimp/types": "^0.14.0", "regenerator-runtime": "^0.13.3" } }, "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA=="],
 
     "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "@jimp/custom/@jimp/core/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/custom/@jimp/core/file-type": ["file-type@9.0.0", "", {}, "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="],
+
+    "@jimp/custom/@jimp/core/pixelmatch": ["pixelmatch@4.0.2", "", { "dependencies": { "pngjs": "^3.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA=="],
+
+    "@jimp/plugins/@jimp/plugin-blit/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-blur/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-circle/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-color/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-contain/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-cover/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-crop/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-displace/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-dither/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-fisheye/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-flip/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-mask/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-print/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-resize/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-rotate/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "@jimp/plugins/@jimp/plugin-threshold/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
+
+    "log-update/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "render-gif/jimp/@jimp/types": ["@jimp/types@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/bmp": "^0.14.0", "@jimp/gif": "^0.14.0", "@jimp/jpeg": "^0.14.0", "@jimp/png": "^0.14.0", "@jimp/tiff": "^0.14.0", "timm": "^1.6.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ=="],
+
+    "@jimp/custom/@jimp/core/pixelmatch/pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
+
+    "log-update/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "log-update/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -6,10 +6,10 @@
       "name": "signal-tui",
       "dependencies": {
         "ink": "^6.5.1",
+        "ink-asciify-image": "^1.1.1",
         "ink-text-input": "^6.0.0",
         "qrcode-terminal": "^0.12.0",
         "react": "^19.2.3",
-        "terminal-image": "^4.2.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -24,89 +24,7 @@
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-mkOh+Wwawzuf5wa30bvc4nA+Qb6DIrGWgBhRR/Pw4T9nsgYait8izvXkNyU78D6Wcu3Z+KUdwCmLCxlWjEotYA=="],
 
-    "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
-
-    "@jimp/bmp": ["@jimp/bmp@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "bmp-js": "^0.1.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A=="],
-
-    "@jimp/core": ["@jimp/core@1.6.0", "", { "dependencies": { "@jimp/file-ops": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "await-to-js": "^3.0.0", "exif-parser": "^0.1.12", "file-type": "^16.0.0", "mime": "3" } }, "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w=="],
-
-    "@jimp/custom": ["@jimp/custom@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/core": "^0.14.0" } }, "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA=="],
-
-    "@jimp/diff": ["@jimp/diff@1.6.0", "", { "dependencies": { "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "pixelmatch": "^5.3.0" } }, "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw=="],
-
-    "@jimp/file-ops": ["@jimp/file-ops@1.6.0", "", {}, "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ=="],
-
-    "@jimp/gif": ["@jimp/gif@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "gifwrap": "^0.9.2", "omggif": "^1.0.9" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg=="],
-
-    "@jimp/jpeg": ["@jimp/jpeg@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "jpeg-js": "^0.4.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ=="],
-
-    "@jimp/js-bmp": ["@jimp/js-bmp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "bmp-ts": "^1.0.9" } }, "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw=="],
-
-    "@jimp/js-gif": ["@jimp/js-gif@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "gifwrap": "^0.10.1", "omggif": "^1.0.10" } }, "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g=="],
-
-    "@jimp/js-jpeg": ["@jimp/js-jpeg@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "jpeg-js": "^0.4.4" } }, "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA=="],
-
-    "@jimp/js-png": ["@jimp/js-png@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "pngjs": "^7.0.0" } }, "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg=="],
-
-    "@jimp/js-tiff": ["@jimp/js-tiff@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "utif2": "^4.1.0" } }, "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw=="],
-
-    "@jimp/plugin-blit": ["@jimp/plugin-blit@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA=="],
-
-    "@jimp/plugin-blur": ["@jimp/plugin-blur@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw=="],
-
-    "@jimp/plugin-circle": ["@jimp/plugin-circle@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw=="],
-
-    "@jimp/plugin-color": ["@jimp/plugin-color@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "tinycolor2": "^1.6.0", "zod": "^3.23.8" } }, "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA=="],
-
-    "@jimp/plugin-contain": ["@jimp/plugin-contain@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ=="],
-
-    "@jimp/plugin-cover": ["@jimp/plugin-cover@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA=="],
-
-    "@jimp/plugin-crop": ["@jimp/plugin-crop@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang=="],
-
-    "@jimp/plugin-displace": ["@jimp/plugin-displace@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q=="],
-
-    "@jimp/plugin-dither": ["@jimp/plugin-dither@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0" } }, "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ=="],
-
-    "@jimp/plugin-fisheye": ["@jimp/plugin-fisheye@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA=="],
-
-    "@jimp/plugin-flip": ["@jimp/plugin-flip@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg=="],
-
-    "@jimp/plugin-gaussian": ["@jimp/plugin-gaussian@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ=="],
-
-    "@jimp/plugin-hash": ["@jimp/plugin-hash@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "any-base": "^1.1.0" } }, "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q=="],
-
-    "@jimp/plugin-invert": ["@jimp/plugin-invert@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg=="],
-
-    "@jimp/plugin-mask": ["@jimp/plugin-mask@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA=="],
-
-    "@jimp/plugin-normalize": ["@jimp/plugin-normalize@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ=="],
-
-    "@jimp/plugin-print": ["@jimp/plugin-print@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/types": "1.6.0", "parse-bmfont-ascii": "^1.0.6", "parse-bmfont-binary": "^1.0.6", "parse-bmfont-xml": "^1.1.6", "simple-xml-to-json": "^1.2.2", "zod": "^3.23.8" } }, "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A=="],
-
-    "@jimp/plugin-quantize": ["@jimp/plugin-quantize@1.6.0", "", { "dependencies": { "image-q": "^4.0.0", "zod": "^3.23.8" } }, "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg=="],
-
-    "@jimp/plugin-resize": ["@jimp/plugin-resize@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA=="],
-
-    "@jimp/plugin-rotate": ["@jimp/plugin-rotate@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw=="],
-
-    "@jimp/plugin-scale": ["@jimp/plugin-scale@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-resize": ">=0.3.5" } }, "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw=="],
-
-    "@jimp/plugin-shadow": ["@jimp/plugin-shadow@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-blur": ">=0.3.5", "@jimp/plugin-resize": ">=0.3.5" } }, "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ=="],
-
-    "@jimp/plugin-threshold": ["@jimp/plugin-threshold@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w=="],
-
-    "@jimp/plugins": ["@jimp/plugins@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/plugin-blit": "^0.14.0", "@jimp/plugin-blur": "^0.14.0", "@jimp/plugin-circle": "^0.14.0", "@jimp/plugin-color": "^0.14.0", "@jimp/plugin-contain": "^0.14.0", "@jimp/plugin-cover": "^0.14.0", "@jimp/plugin-crop": "^0.14.0", "@jimp/plugin-displace": "^0.14.0", "@jimp/plugin-dither": "^0.14.0", "@jimp/plugin-fisheye": "^0.14.0", "@jimp/plugin-flip": "^0.14.0", "@jimp/plugin-gaussian": "^0.14.0", "@jimp/plugin-invert": "^0.14.0", "@jimp/plugin-mask": "^0.14.0", "@jimp/plugin-normalize": "^0.14.0", "@jimp/plugin-print": "^0.14.0", "@jimp/plugin-resize": "^0.14.0", "@jimp/plugin-rotate": "^0.14.0", "@jimp/plugin-scale": "^0.14.0", "@jimp/plugin-shadow": "^0.14.0", "@jimp/plugin-threshold": "^0.14.0", "timm": "^1.6.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw=="],
-
-    "@jimp/png": ["@jimp/png@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "pngjs": "^3.3.3" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA=="],
-
-    "@jimp/tiff": ["@jimp/tiff@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "utif": "^2.0.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw=="],
-
-    "@jimp/types": ["@jimp/types@1.6.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg=="],
-
-    "@jimp/utils": ["@jimp/utils@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "tinycolor2": "^1.6.0" } }, "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA=="],
-
-    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+    "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 
     "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
 
@@ -114,39 +32,15 @@
 
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
-    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
-
-    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
-
     "ansi-escapes": ["ansi-escapes@7.2.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
-
-    "app-path": ["app-path@4.0.0", "", { "dependencies": { "execa": "^5.0.0" } }, "sha512-mgBO9PZJ3MpbKbwFTljTi36ZKBvG5X/fkVR1F85ANsVcVllEb+C0LGNdJfGUm84GpC4xxgN6HFkmkMU8VEO4mA=="],
-
-    "array-range": ["array-range@1.0.1", "", {}, "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA=="],
-
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
-    "await-to-js": ["await-to-js@3.0.0", "", {}, "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g=="],
-
-    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
-
-    "bmp-js": ["bmp-js@0.1.0", "", {}, "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="],
-
-    "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
-
-    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
-
-    "buffer-equal": ["buffer-equal@0.0.1", "", {}, "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="],
-
     "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
-
-    "centra": ["centra@2.7.0", "", { "dependencies": { "follow-redirects": "^1.15.6" } }, "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -160,17 +54,7 @@
 
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
-    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
-
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
-
-    "cycled": ["cycled@1.2.0", "", {}, "sha512-/BOOCEohSBflVHHtY/wUc1F6YDYPqyVs/A837gDoq4H1pm72nU/yChyGt91V4ML+MbbAmHs8uo2l1yJkkTIUdg=="],
-
-    "decode-gif": ["decode-gif@1.0.1", "", { "dependencies": { "array-range": "^1.0.1", "omggif": "^1.0.10" } }, "sha512-L0MT527mwlkil9TiN1xwnJXzUxCup55bUT91CPmQlc9zYejXJ8xp17d5EVnwM80JOIGImBUk1ptJQ+hDihyzwg=="],
-
-    "delay": ["delay@4.4.1", "", {}, "sha512-aL3AhqtfhOlT/3ai6sWXeqwnw63ATNpnUiN4HL7x9q+My5QtHlO3OIkasmug9LKzpheLdmUKGRKnYXYAS7FQkQ=="],
-
-    "dom-walk": ["dom-walk@0.1.2", "", {}, "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -180,105 +64,25 @@
 
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
-    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
-
-    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
-
-    "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
-
-    "exif-parser": ["exif-parser@0.1.12", "", {}, "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="],
-
-    "file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
-
-    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
-
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
-
-    "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
-
-    "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
-
-    "global": ["global@4.4.0", "", { "dependencies": { "min-document": "^2.19.0", "process": "^0.11.10" } }, "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w=="],
-
-    "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
-
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
-
-    "image-dimensions": ["image-dimensions@2.5.0", "", { "bin": { "image-dimensions": "cli.js" } }, "sha512-CKZPHjAEtSg9lBV9eER0bhNn/yrY7cFEQEhkwjLhqLY+Na8lcP1pEyWsaGMGc8t2qbKWA/tuqbhFQpOKGN72Yw=="],
-
-    "image-q": ["image-q@4.0.0", "", { "dependencies": { "@types/node": "16.9.1" } }, "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw=="],
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
     "ink": ["ink@6.5.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.1", "ansi-escapes": "^7.2.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "signal-exit": "^3.0.7", "slice-ansi": "^7.1.0", "stack-utils": "^2.0.6", "string-width": "^8.1.0", "type-fest": "^4.27.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": "^6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-wF3j/DmkM8q5E+OtfdQhCRw8/0ahkc8CUTgEddxZzpEWPslu7YPL3t64MWRoI9m6upVGpfAg4ms2BBvxCdKRLQ=="],
 
+    "ink-asciify-image": ["ink-asciify-image@1.1.1", "", { "peerDependencies": { "ink": ">=4.3.1", "react": ">=18.2.0", "synckit": ">=0.8.5" } }, "sha512-cdQTqakF9iY2VhffwijbF7Qfcu2MqQkAzfaMuR1pNZkTbz2MCI+fOI+maZjqVhvq5uRGZ37pJnGlUrdvXerqhA=="],
+
     "ink-text-input": ["ink-text-input@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "type-fest": "^4.18.2" }, "peerDependencies": { "ink": ">=5", "react": ">=18" } }, "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
-    "is-function": ["is-function@1.0.2", "", {}, "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="],
-
     "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
-
-    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
-
-    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
-    "iterm2-version": ["iterm2-version@5.0.0", "", { "dependencies": { "app-path": "^4.0.0", "plist": "^3.0.2" } }, "sha512-WdLXcMYvN3SXT6vEtuW78vnZs4pVWm2nBnb4VKjOPPXmdlR1xTHmBgqKacOzAe4RXOiY/V+0u/0zsU3LoGQoBg=="],
-
-    "jimp": ["jimp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/diff": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-gif": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-blur": "1.6.0", "@jimp/plugin-circle": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-contain": "1.6.0", "@jimp/plugin-cover": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-displace": "1.6.0", "@jimp/plugin-dither": "1.6.0", "@jimp/plugin-fisheye": "1.6.0", "@jimp/plugin-flip": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/plugin-mask": "1.6.0", "@jimp/plugin-print": "1.6.0", "@jimp/plugin-quantize": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/plugin-rotate": "1.6.0", "@jimp/plugin-threshold": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg=="],
-
-    "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
-
-    "load-bmfont": ["load-bmfont@1.4.2", "", { "dependencies": { "buffer-equal": "0.0.1", "mime": "^1.3.4", "parse-bmfont-ascii": "^1.0.3", "parse-bmfont-binary": "^1.0.5", "parse-bmfont-xml": "^1.1.4", "phin": "^3.7.1", "xhr": "^2.0.1", "xtend": "^4.0.0" } }, "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog=="],
-
-    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
-
-    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
-
-    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
-    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
-
-    "min-document": ["min-document@2.19.2", "", { "dependencies": { "dom-walk": "^0.1.0" } }, "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A=="],
-
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
-    "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
-
-    "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
-
-    "omggif": ["omggif@1.0.10", "", {}, "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="],
-
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
-    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
-
-    "parse-bmfont-ascii": ["parse-bmfont-ascii@1.0.6", "", {}, "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="],
-
-    "parse-bmfont-binary": ["parse-bmfont-binary@1.0.6", "", {}, "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="],
-
-    "parse-bmfont-xml": ["parse-bmfont-xml@1.1.6", "", { "dependencies": { "xml-parse-from-string": "^1.0.0", "xml2js": "^0.5.0" } }, "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA=="],
-
-    "parse-headers": ["parse-headers@2.0.6", "", {}, "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="],
-
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
-
-    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
-
-    "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
-
-    "phin": ["phin@2.9.3", "", {}, "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="],
-
-    "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
-
-    "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
-
-    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
-
-    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "qrcode-terminal": ["qrcode-terminal@0.12.0", "", { "bin": { "qrcode-terminal": "./bin/qrcode-terminal.js" } }, "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="],
 
@@ -288,31 +92,13 @@
 
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
-    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
-
-    "readable-web-to-node-stream": ["readable-web-to-node-stream@3.0.4", "", { "dependencies": { "readable-stream": "^4.7.0" } }, "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw=="],
-
-    "regenerator-runtime": ["regenerator-runtime@0.13.11", "", {}, "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="],
-
-    "render-gif": ["render-gif@2.0.4", "", { "dependencies": { "cycled": "^1.2.0", "decode-gif": "^1.0.1", "delay": "^4.3.0", "jimp": "^0.14.0" } }, "sha512-l5X7EwbEvdflnvVAzjL7njizwZN8ATqJ0rdaQ5WwMJ55vyWXIXIUE9Ut7W6hm+KE+HMYn5C0a+7t0B6JjGfxQA=="],
-
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "sax": ["sax@1.4.3", "", {}, "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ=="],
-
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
-    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
-
-    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "simple-xml-to-json": ["simple-xml-to-json@1.2.3", "", {}, "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA=="],
 
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
@@ -320,25 +106,9 @@
 
     "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
 
-    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
-
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
-
-    "strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
-
-    "supports-terminal-graphics": ["supports-terminal-graphics@0.1.0", "", {}, "sha512-+KdfozhS0Fw8y5Sghw8kkZNGT8nWYzJ1EzcoIvVjxhl+26TJTs26y02yfBgvc1jh5AS/c8jcI3xtahhR95KRyQ=="],
-
-    "term-img": ["term-img@7.1.0", "", { "dependencies": { "ansi-escapes": "^7.1.1", "iterm2-version": "^5.0.0" } }, "sha512-au++khgSDly2KXNhC6BOU3mLi2v+Dk5mChYKDcpB5xYwhlwqYQtj0z59dIqFEmr+w7ndZaNqurHapkGc6/hprQ=="],
-
-    "terminal-image": ["terminal-image@4.2.0", "", { "dependencies": { "chalk": "^5.6.2", "image-dimensions": "^2.5.0", "jimp": "^1.6.0", "log-update": "^6.1.0", "render-gif": "^2.0.4", "supports-terminal-graphics": "^0.1.0", "term-img": "^7.0.0" } }, "sha512-KlK1fgS2AjAg9wmC998ys1uHNXyRb61hgBrSMWK/n+uthMIPejkhYhVcZfQ1ikI99BhiqP6Exr4ISfiNStGdkg=="],
-
-    "timm": ["timm@1.7.1", "", {}, "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="],
-
-    "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
-
-    "token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
+    "synckit": ["synckit@0.11.11", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
@@ -346,156 +116,18 @@
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
-    "utif": ["utif@2.0.1", "", { "dependencies": { "pako": "^1.0.5" } }, "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg=="],
-
-    "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
-
-    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
-
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
-    "xhr": ["xhr@2.6.0", "", { "dependencies": { "global": "~4.4.0", "is-function": "^1.0.1", "parse-headers": "^2.0.0", "xtend": "^4.0.0" } }, "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA=="],
-
-    "xml-parse-from-string": ["xml-parse-from-string@1.0.1", "", {}, "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="],
-
-    "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
-
-    "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
-
-    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
-
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@jimp/bmp/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/custom/@jimp/core": ["@jimp/core@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "any-base": "^1.1.0", "buffer": "^5.2.0", "exif-parser": "^0.1.12", "file-type": "^9.0.0", "load-bmfont": "^1.3.1", "mkdirp": "^0.5.1", "phin": "^2.9.1", "pixelmatch": "^4.0.2", "tinycolor2": "^1.4.1" } }, "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w=="],
-
-    "@jimp/gif/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/gif/gifwrap": ["gifwrap@0.9.4", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ=="],
-
-    "@jimp/jpeg/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugin-gaussian/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugin-invert/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugin-normalize/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugin-scale/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugin-shadow/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-blit": ["@jimp/plugin-blit@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw=="],
-
-    "@jimp/plugins/@jimp/plugin-blur": ["@jimp/plugin-blur@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ=="],
-
-    "@jimp/plugins/@jimp/plugin-circle": ["@jimp/plugin-circle@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA=="],
-
-    "@jimp/plugins/@jimp/plugin-color": ["@jimp/plugin-color@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "tinycolor2": "^1.4.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ=="],
-
-    "@jimp/plugins/@jimp/plugin-contain": ["@jimp/plugin-contain@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-blit": ">=0.3.5", "@jimp/plugin-resize": ">=0.3.5", "@jimp/plugin-scale": ">=0.3.5" } }, "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg=="],
-
-    "@jimp/plugins/@jimp/plugin-cover": ["@jimp/plugin-cover@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-crop": ">=0.3.5", "@jimp/plugin-resize": ">=0.3.5", "@jimp/plugin-scale": ">=0.3.5" } }, "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ=="],
-
-    "@jimp/plugins/@jimp/plugin-crop": ["@jimp/plugin-crop@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug=="],
-
-    "@jimp/plugins/@jimp/plugin-displace": ["@jimp/plugin-displace@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg=="],
-
-    "@jimp/plugins/@jimp/plugin-dither": ["@jimp/plugin-dither@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ=="],
-
-    "@jimp/plugins/@jimp/plugin-fisheye": ["@jimp/plugin-fisheye@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg=="],
-
-    "@jimp/plugins/@jimp/plugin-flip": ["@jimp/plugin-flip@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-rotate": ">=0.3.5" } }, "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw=="],
-
-    "@jimp/plugins/@jimp/plugin-mask": ["@jimp/plugin-mask@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA=="],
-
-    "@jimp/plugins/@jimp/plugin-print": ["@jimp/plugin-print@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0", "load-bmfont": "^1.4.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-blit": ">=0.3.5" } }, "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ=="],
-
-    "@jimp/plugins/@jimp/plugin-resize": ["@jimp/plugin-resize@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ=="],
-
-    "@jimp/plugins/@jimp/plugin-rotate": ["@jimp/plugin-rotate@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-blit": ">=0.3.5", "@jimp/plugin-crop": ">=0.3.5", "@jimp/plugin-resize": ">=0.3.5" } }, "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q=="],
-
-    "@jimp/plugins/@jimp/plugin-threshold": ["@jimp/plugin-threshold@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/utils": "^0.14.0" }, "peerDependencies": { "@jimp/custom": ">=0.3.5", "@jimp/plugin-color": ">=0.8.0", "@jimp/plugin-resize": ">=0.8.0" } }, "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw=="],
-
-    "@jimp/png/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/png/pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
-
-    "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
-
     "ink/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
-
-    "load-bmfont/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
-
-    "load-bmfont/phin": ["phin@3.7.1", "", { "dependencies": { "centra": "^2.7.0" } }, "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ=="],
-
-    "log-update/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
-
-    "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
-
-    "readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
-    "render-gif/jimp": ["jimp@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/custom": "^0.14.0", "@jimp/plugins": "^0.14.0", "@jimp/types": "^0.14.0", "regenerator-runtime": "^0.13.3" } }, "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA=="],
 
     "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
-
-    "@jimp/custom/@jimp/core/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/custom/@jimp/core/file-type": ["file-type@9.0.0", "", {}, "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="],
-
-    "@jimp/custom/@jimp/core/pixelmatch": ["pixelmatch@4.0.2", "", { "dependencies": { "pngjs": "^3.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA=="],
-
-    "@jimp/plugins/@jimp/plugin-blit/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-blur/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-circle/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-color/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-contain/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-cover/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-crop/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-displace/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-dither/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-fisheye/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-flip/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-mask/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-print/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-resize/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-rotate/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "@jimp/plugins/@jimp/plugin-threshold/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
-
-    "log-update/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
-
-    "render-gif/jimp/@jimp/types": ["@jimp/types@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "@jimp/bmp": "^0.14.0", "@jimp/gif": "^0.14.0", "@jimp/jpeg": "^0.14.0", "@jimp/png": "^0.14.0", "@jimp/tiff": "^0.14.0", "timm": "^1.6.1" }, "peerDependencies": { "@jimp/custom": ">=0.3.5" } }, "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ=="],
-
-    "@jimp/custom/@jimp/core/pixelmatch/pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
-
-    "log-update/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
-
-    "log-update/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "dependencies": {
     "ink": "^6.5.1",
+    "ink-asciify-image": "^1.1.1",
     "ink-text-input": "^6.0.0",
     "qrcode-terminal": "^0.12.0",
-    "react": "^19.2.3",
-    "terminal-image": "^4.2.0"
+    "react": "^19.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ink": "^6.5.1",
     "ink-text-input": "^6.0.0",
     "qrcode-terminal": "^0.12.0",
-    "react": "^19.2.3"
+    "react": "^19.2.3",
+    "terminal-image": "^4.2.0"
   }
 }

--- a/src/core/MessageStorage.test.ts
+++ b/src/core/MessageStorage.test.ts
@@ -442,4 +442,395 @@ describe("MessageStorage", () => {
         storage.close();
         await unlink(dbPath);
     });
+
+    // =====================================================
+    // Attachment storage tests
+    // =====================================================
+
+    test("should save and retrieve message with single attachment", async () => {
+        const msg = {
+            id: "msg-with-attachment",
+            sender: "Me",
+            content: "Check this out",
+            timestamp: Date.now(),
+            isOutgoing: true,
+            attachments: [{
+                id: "att-1",
+                contentType: "image/jpeg",
+                filename: "photo.jpg",
+                size: 12345,
+                width: 800,
+                height: 600
+            }]
+        };
+        const conversationId = "+1234567890";
+
+        storage.addMessage(msg, conversationId);
+        const retrieved = storage.getMessages(conversationId);
+
+        expect(retrieved.length).toBe(1);
+        expect(retrieved[0]!.attachments).toBeDefined();
+        expect(retrieved[0]!.attachments!.length).toBe(1);
+        expect(retrieved[0]!.attachments![0]!.contentType).toBe("image/jpeg");
+        expect(retrieved[0]!.attachments![0]!.filename).toBe("photo.jpg");
+        expect(retrieved[0]!.attachments![0]!.size).toBe(12345);
+        expect(retrieved[0]!.attachments![0]!.width).toBe(800);
+        expect(retrieved[0]!.attachments![0]!.height).toBe(600);
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("should save and retrieve message with multiple attachments", async () => {
+        const msg = {
+            id: "msg-multi-attach",
+            sender: "Me",
+            content: "Multiple files",
+            timestamp: Date.now(),
+            isOutgoing: true,
+            attachments: [
+                { id: "att-1", contentType: "image/png", filename: "image1.png" },
+                { id: "att-2", contentType: "image/jpeg", filename: "image2.jpg" },
+                { id: "att-3", contentType: "audio/mp3", filename: "voice.mp3" }
+            ]
+        };
+        const conversationId = "+1234567890";
+
+        storage.addMessage(msg, conversationId);
+        const retrieved = storage.getMessages(conversationId);
+
+        expect(retrieved[0]!.attachments!.length).toBe(3);
+        expect(retrieved[0]!.attachments![0]!.filename).toBe("image1.png");
+        expect(retrieved[0]!.attachments![1]!.filename).toBe("image2.jpg");
+        expect(retrieved[0]!.attachments![2]!.filename).toBe("voice.mp3");
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("should save and retrieve attachment with asciiArt field", async () => {
+        const asciiArt = "###\n###\n###";
+        const msg = {
+            id: "msg-ascii-art",
+            sender: "Me",
+            content: "",
+            timestamp: Date.now(),
+            isOutgoing: true,
+            attachments: [{
+                id: "att-ascii",
+                contentType: "image/png",
+                filename: "photo.png",
+                asciiArt: asciiArt
+            }]
+        };
+        const conversationId = "+1234567890";
+
+        storage.addMessage(msg, conversationId);
+        const retrieved = storage.getMessages(conversationId);
+
+        expect(retrieved[0]!.attachments![0]!.asciiArt).toBe(asciiArt);
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("should save attachment with downloadStatus and localPath", async () => {
+        const msg = {
+            id: "msg-download-status",
+            sender: "+1234567890",
+            content: "",
+            timestamp: Date.now(),
+            isOutgoing: false,
+            attachments: [{
+                id: "att-status",
+                contentType: "image/jpeg",
+                filename: "received.jpg",
+                downloadStatus: "completed" as const,
+                localPath: "/path/to/local/file.jpg"
+            }]
+        };
+        const conversationId = "+1234567890";
+
+        storage.addMessage(msg, conversationId);
+        const retrieved = storage.getMessages(conversationId);
+
+        expect(retrieved[0]!.attachments![0]!.downloadStatus).toBe("completed");
+        expect(retrieved[0]!.attachments![0]!.localPath).toBe("/path/to/local/file.jpg");
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("should handle message without attachments (undefined)", async () => {
+        const msg = {
+            id: "msg-no-attach",
+            sender: "Me",
+            content: "Just text",
+            timestamp: Date.now(),
+            isOutgoing: true
+        };
+        const conversationId = "+1234567890";
+
+        storage.addMessage(msg, conversationId);
+        const retrieved = storage.getMessages(conversationId);
+
+        expect(retrieved[0]!.attachments).toBeUndefined();
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("should handle attachment with only required fields", async () => {
+        const msg = {
+            id: "msg-minimal-attach",
+            sender: "Me",
+            content: "",
+            timestamp: Date.now(),
+            isOutgoing: true,
+            attachments: [{
+                contentType: "application/octet-stream"
+                // No id, filename, size, etc.
+            }]
+        };
+        const conversationId = "+1234567890";
+
+        storage.addMessage(msg, conversationId);
+        const retrieved = storage.getMessages(conversationId);
+
+        expect(retrieved[0]!.attachments).toBeDefined();
+        expect(retrieved[0]!.attachments![0]!.contentType).toBe("application/octet-stream");
+        expect(retrieved[0]!.attachments![0]!.filename).toBeUndefined();
+        expect(retrieved[0]!.attachments![0]!.size).toBeUndefined();
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    // =====================================================
+    // updateAttachmentStatus tests
+    // =====================================================
+
+    test("updateAttachmentStatus should update status to downloading", async () => {
+        const msg = {
+            id: "msg-att-update",
+            sender: "+1234567890",
+            content: "",
+            timestamp: Date.now(),
+            isOutgoing: false,
+            attachments: [{
+                id: "att-to-update",
+                contentType: "image/jpeg",
+                downloadStatus: "pending" as const
+            }]
+        };
+        const conversationId = "+1234567890";
+
+        storage.addMessage(msg, conversationId);
+        storage.updateAttachmentStatus("att-to-update", "downloading");
+
+        const retrieved = storage.getMessages(conversationId);
+        expect(retrieved[0]!.attachments![0]!.downloadStatus).toBe("downloading");
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("updateAttachmentStatus should update status to completed with localPath", async () => {
+        const msg = {
+            id: "msg-att-complete",
+            sender: "+1234567890",
+            content: "",
+            timestamp: Date.now(),
+            isOutgoing: false,
+            attachments: [{
+                id: "att-completing",
+                contentType: "image/jpeg",
+                downloadStatus: "downloading" as const
+            }]
+        };
+        const conversationId = "+1234567890";
+
+        storage.addMessage(msg, conversationId);
+        storage.updateAttachmentStatus("att-completing", "completed", "/downloads/photo.jpg");
+
+        const retrieved = storage.getMessages(conversationId);
+        expect(retrieved[0]!.attachments![0]!.downloadStatus).toBe("completed");
+        expect(retrieved[0]!.attachments![0]!.localPath).toBe("/downloads/photo.jpg");
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("updateAttachmentStatus should update status to failed", async () => {
+        const msg = {
+            id: "msg-att-fail",
+            sender: "+1234567890",
+            content: "",
+            timestamp: Date.now(),
+            isOutgoing: false,
+            attachments: [{
+                id: "att-failing",
+                contentType: "image/jpeg",
+                downloadStatus: "downloading" as const
+            }]
+        };
+        const conversationId = "+1234567890";
+
+        storage.addMessage(msg, conversationId);
+        storage.updateAttachmentStatus("att-failing", "failed");
+
+        const retrieved = storage.getMessages(conversationId);
+        expect(retrieved[0]!.attachments![0]!.downloadStatus).toBe("failed");
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("updateAttachmentStatus should emit attachment-updated event", async () => {
+        const msg = {
+            id: "msg-att-event",
+            sender: "+1234567890",
+            content: "",
+            timestamp: Date.now(),
+            isOutgoing: false,
+            attachments: [{
+                id: "att-event-test",
+                contentType: "image/jpeg",
+                downloadStatus: "pending" as const
+            }]
+        };
+        const conversationId = "+1234567890";
+
+        storage.addMessage(msg, conversationId);
+
+        const eventPromise = new Promise<{ id: string; status: string; path?: string }>((resolve) => {
+            storage.on("attachment-updated", (id, status, path) => {
+                resolve({ id, status, path });
+            });
+        });
+
+        storage.updateAttachmentStatus("att-event-test", "completed", "/path/to/file.jpg");
+
+        const result = await eventPromise;
+        expect(result.id).toBe("att-event-test");
+        expect(result.status).toBe("completed");
+        expect(result.path).toBe("/path/to/file.jpg");
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("updateAttachmentStatus should preserve existing localPath if not provided", async () => {
+        const msg = {
+            id: "msg-att-preserve-path",
+            sender: "+1234567890",
+            content: "",
+            timestamp: Date.now(),
+            isOutgoing: false,
+            attachments: [{
+                id: "att-preserve",
+                contentType: "image/jpeg",
+                downloadStatus: "completed" as const,
+                localPath: "/existing/path.jpg"
+            }]
+        };
+        const conversationId = "+1234567890";
+
+        storage.addMessage(msg, conversationId);
+        // Update status without providing localPath
+        storage.updateAttachmentStatus("att-preserve", "failed");
+
+        const retrieved = storage.getMessages(conversationId);
+        expect(retrieved[0]!.attachments![0]!.downloadStatus).toBe("failed");
+        expect(retrieved[0]!.attachments![0]!.localPath).toBe("/existing/path.jpg");
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    // =====================================================
+    // replaceMessage with attachments tests
+    // =====================================================
+
+    test("replaceMessage should handle old message with attachments", async () => {
+        const conversationId = "+1234567890";
+        const oldId = "optimistic-with-attach";
+        const oldMessage = {
+            id: oldId,
+            sender: "Me",
+            content: "Sending image...",
+            timestamp: Date.now(),
+            isOutgoing: true,
+            attachments: [{
+                id: "temp-att",
+                contentType: "image/jpeg",
+                filename: "photo.jpg"
+            }]
+        };
+
+        storage.addMessage(oldMessage, conversationId);
+
+        const newMessage = {
+            id: "confirmed-with-attach",
+            sender: "Me",
+            content: "Sending image...",
+            timestamp: Date.now() + 100,
+            isOutgoing: true,
+            attachments: [{
+                id: "confirmed-att",
+                contentType: "image/jpeg",
+                filename: "photo.jpg",
+                downloadStatus: "completed" as const
+            }]
+        };
+
+        storage.replaceMessage(oldId, newMessage, conversationId);
+
+        const messages = storage.getMessages(conversationId);
+        expect(messages.length).toBe(1);
+        expect(messages[0]!.id).toBe("confirmed-with-attach");
+        expect(messages[0]!.attachments![0]!.id).toBe("confirmed-att");
+        expect(messages[0]!.attachments![0]!.downloadStatus).toBe("completed");
+
+        storage.close();
+        await unlink(dbPath);
+    });
+
+    test("replaceMessage should remove old attachments when message is deleted", async () => {
+        const conversationId = "+1234567890";
+        const oldId = "msg-to-replace";
+        const oldMessage = {
+            id: oldId,
+            sender: "Me",
+            content: "Old message",
+            timestamp: Date.now(),
+            isOutgoing: true,
+            attachments: [{
+                id: "old-att-1",
+                contentType: "image/png",
+                filename: "old.png"
+            }]
+        };
+
+        storage.addMessage(oldMessage, conversationId);
+
+        const newMessage = {
+            id: "new-msg",
+            sender: "Me",
+            content: "New message",
+            timestamp: Date.now() + 100,
+            isOutgoing: true
+            // No attachments
+        };
+
+        storage.replaceMessage(oldId, newMessage, conversationId);
+
+        const messages = storage.getMessages(conversationId);
+        expect(messages.length).toBe(1);
+        expect(messages[0]!.id).toBe("new-msg");
+        expect(messages[0]!.attachments).toBeUndefined();
+
+        storage.close();
+        await unlink(dbPath);
+    });
 });

--- a/src/core/MessageStorage.ts
+++ b/src/core/MessageStorage.ts
@@ -69,9 +69,17 @@ export class MessageStorage extends EventEmitter {
         caption TEXT,
         local_path TEXT,
         download_status TEXT DEFAULT 'pending',
+        ascii_art TEXT,
         FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE
       )
     `).run();
+
+    // Auto-migrate: Add ascii_art column if it doesn't exist
+    try {
+      this.db!.query("ALTER TABLE attachments ADD COLUMN ascii_art TEXT").run();
+    } catch (e) {
+      // Ignore error if column already exists
+    }
 
     this.db!.query(`
       CREATE INDEX IF NOT EXISTS idx_attachments_message
@@ -118,10 +126,10 @@ export class MessageStorage extends EventEmitter {
       const attachmentQuery = this.db!.query(`
         INSERT OR REPLACE INTO attachments (
           id, message_id, content_type, filename, size,
-          width, height, caption, local_path, download_status
+          width, height, caption, local_path, download_status, ascii_art
         ) VALUES (
           $id, $message_id, $content_type, $filename, $size,
-          $width, $height, $caption, $local_path, $download_status
+          $width, $height, $caption, $local_path, $download_status, $ascii_art
         )
       `);
 
@@ -137,7 +145,8 @@ export class MessageStorage extends EventEmitter {
           $height: att.height || null,
           $caption: att.caption || null,
           $local_path: att.localPath || null,
-          $download_status: att.downloadStatus || "pending"
+          $download_status: att.downloadStatus || "pending",
+          $ascii_art: att.asciiArt || null
         });
       }
     }
@@ -201,7 +210,8 @@ export class MessageStorage extends EventEmitter {
             height: a.height || undefined,
             caption: a.caption || undefined,
             localPath: a.local_path || undefined,
-            downloadStatus: a.download_status as Attachment["downloadStatus"]
+            downloadStatus: a.download_status as Attachment["downloadStatus"],
+            asciiArt: a.ascii_art || undefined
           }))
         : undefined;
 

--- a/src/core/MessageStorage.ts
+++ b/src/core/MessageStorage.ts
@@ -50,8 +50,11 @@ export class MessageStorage extends EventEmitter {
       // Auto-migrate: Try to add status column if it doesn't exist
       try {
         this.db!.query("ALTER TABLE messages ADD COLUMN status TEXT DEFAULT 'sent'").run();
-      } catch (e) {
-        // Ignore error if column likely exists
+      } catch (e: any) {
+        // Only ignore "duplicate column" errors, rethrow others
+        if (!e.message?.includes("duplicate column")) {
+          throw e;
+        }
       }
 
       this.db!.query(`
@@ -80,8 +83,11 @@ export class MessageStorage extends EventEmitter {
     // Auto-migrate: Add ascii_art column if it doesn't exist
     try {
       this.db!.query("ALTER TABLE attachments ADD COLUMN ascii_art TEXT").run();
-    } catch (e) {
-      // Ignore error if column already exists
+    } catch (e: any) {
+      // Only ignore "duplicate column" errors, rethrow others
+      if (!e.message?.includes("duplicate column")) {
+        throw e;
+      }
     }
 
     this.db!.query(`

--- a/src/core/MessageStorage.ts
+++ b/src/core/MessageStorage.ts
@@ -4,7 +4,7 @@ import { dirname } from "node:path";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { EventEmitter } from "node:events";
-import type { ChatMessage } from "../types/types";
+import type { ChatMessage, Attachment } from "../types/types.ts";
 
 export class MessageStorage extends EventEmitter {
   private db?: Database;
@@ -52,9 +52,31 @@ export class MessageStorage extends EventEmitter {
       }
 
       this.db!.query(`
-      CREATE INDEX IF NOT EXISTS idx_conversation_timestamp 
+      CREATE INDEX IF NOT EXISTS idx_conversation_timestamp
       ON messages(conversation_id, timestamp);
     `);
+
+    // Create attachments table
+    this.db!.query(`
+      CREATE TABLE IF NOT EXISTS attachments (
+        id TEXT PRIMARY KEY,
+        message_id TEXT NOT NULL,
+        content_type TEXT NOT NULL,
+        filename TEXT,
+        size INTEGER,
+        width INTEGER,
+        height INTEGER,
+        caption TEXT,
+        local_path TEXT,
+        download_status TEXT DEFAULT 'pending',
+        FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE
+      )
+    `).run();
+
+    this.db!.query(`
+      CREATE INDEX IF NOT EXISTS idx_attachments_message
+      ON attachments(message_id)
+    `).run();
 
     this.initialized = true;
   }
@@ -90,6 +112,35 @@ export class MessageStorage extends EventEmitter {
       $is_outgoing: msg.isOutgoing ? 1 : 0,
       $status: msg.status || "sent"
     });
+
+    // Save attachments if present
+    if (msg.attachments && msg.attachments.length > 0) {
+      const attachmentQuery = this.db!.query(`
+        INSERT OR REPLACE INTO attachments (
+          id, message_id, content_type, filename, size,
+          width, height, caption, local_path, download_status
+        ) VALUES (
+          $id, $message_id, $content_type, $filename, $size,
+          $width, $height, $caption, $local_path, $download_status
+        )
+      `);
+
+      for (let i = 0; i < msg.attachments.length; i++) {
+        const att = msg.attachments[i];
+        attachmentQuery.run({
+          $id: att.id || `${msg.id}-${i}`,
+          $message_id: msg.id,
+          $content_type: att.contentType,
+          $filename: att.filename || null,
+          $size: att.size || null,
+          $width: att.width || null,
+          $height: att.height || null,
+          $caption: att.caption || null,
+          $local_path: att.localPath || null,
+          $download_status: att.downloadStatus || "pending"
+        });
+      }
+    }
   }
 
   /**
@@ -132,16 +183,39 @@ export class MessageStorage extends EventEmitter {
     const query = this.db!.query(sql);
     const rows = query.all(params) as any[];
 
+    // Load attachments for all messages in this batch
+    const attachmentQuery = this.db!.query(`
+      SELECT * FROM attachments WHERE message_id = $message_id
+    `);
+
     // Convert back to ChatMessage objects and reverse (so oldest is first)
-    return rows.map(row => ({
-      id: row.id,
-      sender: row.sender,
-      senderName: row.sender_name || undefined,
-      content: row.content,
-      timestamp: row.timestamp,
-      isOutgoing: Boolean(row.is_outgoing),
-      status: row.status as "sent" | "delivered" | "read" | "failed" | undefined
-    })).reverse();
+    return rows.map(row => {
+      const attachmentRows = attachmentQuery.all({ $message_id: row.id }) as any[];
+      const attachments: Attachment[] | undefined = attachmentRows.length > 0
+        ? attachmentRows.map(a => ({
+            id: a.id,
+            contentType: a.content_type,
+            filename: a.filename || undefined,
+            size: a.size || undefined,
+            width: a.width || undefined,
+            height: a.height || undefined,
+            caption: a.caption || undefined,
+            localPath: a.local_path || undefined,
+            downloadStatus: a.download_status as Attachment["downloadStatus"]
+          }))
+        : undefined;
+
+      return {
+        id: row.id,
+        sender: row.sender,
+        senderName: row.sender_name || undefined,
+        content: row.content,
+        timestamp: row.timestamp,
+        isOutgoing: Boolean(row.is_outgoing),
+        status: row.status as "sent" | "delivered" | "read" | "failed" | undefined,
+        attachments
+      };
+    }).reverse();
   }
 
   updateMessageStatus(timestamp: number, status: "sent" | "delivered" | "read" | "failed"): void {
@@ -174,6 +248,31 @@ export class MessageStorage extends EventEmitter {
 
     // Emit event for UI to react
     this.emit("status-updated", timestamp, status);
+  }
+
+  /**
+   * Update attachment download status and local path
+   */
+  updateAttachmentStatus(
+    attachmentId: string,
+    status: "pending" | "downloading" | "completed" | "failed",
+    localPath?: string
+  ): void {
+    if (!this.db) throw new Error("Database not initialized. Call init() first.");
+
+    const query = this.db.query(`
+      UPDATE attachments
+      SET download_status = $status, local_path = COALESCE($local_path, local_path)
+      WHERE id = $id
+    `);
+
+    query.run({
+      $id: attachmentId,
+      $status: status,
+      $local_path: localPath || null
+    });
+
+    this.emit("attachment-updated", attachmentId, status, localPath);
   }
 
   getConversationLastMessage(conversationId: string): { timestamp: number; content: string } | null {

--- a/src/core/MessageStorage.ts
+++ b/src/core/MessageStorage.ts
@@ -30,6 +30,9 @@ export class MessageStorage extends EventEmitter {
     // Create database
     this.db = new Database(this.dbPath, { create: true });
 
+    // Enable foreign key constraints
+    this.db!.query("PRAGMA foreign_keys = ON").run();
+
     // Create tables
       this.db!.query(`
         CREATE TABLE IF NOT EXISTS messages (
@@ -173,10 +176,10 @@ export class MessageStorage extends EventEmitter {
   getMessages(conversationId: string, limit: number = 50, beforeTimestamp?: number): ChatMessage[] {
     if (!this.db) throw new Error("Database not initialized. Call init() first.");
     let sql = `
-      SELECT * FROM messages 
+      SELECT * FROM messages
       WHERE conversation_id = $conversation_id
     `;
-    
+
     const params: any = {
       $conversation_id: conversationId,
       $limit: limit
@@ -192,28 +195,45 @@ export class MessageStorage extends EventEmitter {
     const query = this.db!.query(sql);
     const rows = query.all(params) as any[];
 
-    // Load attachments for all messages in this batch
-    const attachmentQuery = this.db!.query(`
-      SELECT * FROM attachments WHERE message_id = $message_id
-    `);
+    // Batch load all attachments for messages in this result set (fixes N+1 query)
+    const messageIds = rows.map(row => row.id);
+    const attachmentsByMessageId = new Map<string, Attachment[]>();
+
+    if (messageIds.length > 0) {
+      // Use a single query with IN clause to fetch all attachments at once
+      const placeholders = messageIds.map(() => "?").join(", ");
+      const attachmentQuery = this.db!.query(`
+        SELECT * FROM attachments WHERE message_id IN (${placeholders})
+      `);
+      const attachmentRows = attachmentQuery.all(...messageIds) as any[];
+
+      // Group attachments by message_id
+      for (const a of attachmentRows) {
+        const attachment: Attachment = {
+          id: a.id,
+          contentType: a.content_type,
+          filename: a.filename || undefined,
+          size: a.size || undefined,
+          width: a.width || undefined,
+          height: a.height || undefined,
+          caption: a.caption || undefined,
+          localPath: a.local_path || undefined,
+          downloadStatus: a.download_status as Attachment["downloadStatus"],
+          asciiArt: a.ascii_art || undefined
+        };
+
+        const existing = attachmentsByMessageId.get(a.message_id);
+        if (existing) {
+          existing.push(attachment);
+        } else {
+          attachmentsByMessageId.set(a.message_id, [attachment]);
+        }
+      }
+    }
 
     // Convert back to ChatMessage objects and reverse (so oldest is first)
     return rows.map(row => {
-      const attachmentRows = attachmentQuery.all({ $message_id: row.id }) as any[];
-      const attachments: Attachment[] | undefined = attachmentRows.length > 0
-        ? attachmentRows.map(a => ({
-            id: a.id,
-            contentType: a.content_type,
-            filename: a.filename || undefined,
-            size: a.size || undefined,
-            width: a.width || undefined,
-            height: a.height || undefined,
-            caption: a.caption || undefined,
-            localPath: a.local_path || undefined,
-            downloadStatus: a.download_status as Attachment["downloadStatus"],
-            asciiArt: a.ascii_art || undefined
-          }))
-        : undefined;
+      const attachments = attachmentsByMessageId.get(row.id);
 
       return {
         id: row.id,

--- a/src/core/SignalClient.ts
+++ b/src/core/SignalClient.ts
@@ -228,17 +228,31 @@ export class SignalClient extends EventEmitter {
   /**
    * Send a message to a recipient
    * @param recipient - Phone number, UUID, or group ID
-   * @param message - The message text
-   * @param isGroup - Whether this is a group message
+   * @param message - The message text (optional if sending attachments)
+   * @param options - Optional settings: isGroup, attachments (array of file paths)
    * @returns Promise that resolves with the message timestamp
    */
-  async sendMessage(recipient: string, message: string, isGroup: boolean = false): Promise<number> {
-    const params: Record<string, unknown> = { message };
-    if (isGroup) {
+  async sendMessage(
+    recipient: string,
+    message?: string,
+    options: { isGroup?: boolean; attachments?: string[] } = {}
+  ): Promise<number> {
+    const params: Record<string, unknown> = {};
+
+    if (message) {
+      params.message = message;
+    }
+
+    if (options.attachments && options.attachments.length > 0) {
+      params.attachments = options.attachments;
+    }
+
+    if (options.isGroup) {
       params.groupId = recipient;
     } else {
       params.recipient = [recipient];
     }
+
     const response = await this.sendRequest<{ timestamp: number }>("send", params);
     return response.timestamp;
   }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -103,6 +103,8 @@ export interface Attachment {
   // Local storage fields
   localPath?: string;
   downloadStatus?: "pending" | "downloading" | "completed" | "failed";
+  // Pre-generated ASCII art for images
+  asciiArt?: string;
 }
 
 export interface ReadMessage {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -100,6 +100,9 @@ export interface Attachment {
   width?: number;
   height?: number;
   caption?: string;
+  // Local storage fields
+  localPath?: string;
+  downloadStatus?: "pending" | "downloading" | "completed" | "failed";
 }
 
 export interface ReadMessage {
@@ -210,5 +213,6 @@ export interface ChatMessage {
   timestamp: number;
   isOutgoing: boolean;  // true if sent by us
   status?: "sent" | "delivered" | "read" | "failed";
+  attachments?: Attachment[];
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -57,6 +57,7 @@ export interface SyncMessage {
     message?: string;
     expiresInSeconds?: number;
     groupInfo?: GroupInfo;
+    attachments?: Attachment[];
   };
   readMessages?: ReadMessage[];
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -10,6 +10,7 @@ import type { ConnectionStatus } from "./components/StatusBar.tsx";
 import type { Account, Conversation, SignalEnvelope, ChatMessage, Attachment } from "../types/types.ts";
 import { MessageStorage } from "../core/MessageStorage.ts";
 import { normalizeNumber } from "../utils/phone.ts";
+import { generateAsciiArt } from "../utils/asciiArt.ts";
 
 // Get signal-cli's attachment storage directory
 function getSignalCliAttachmentsDir(): string {
@@ -210,7 +211,7 @@ export default function App() {
     });
 
     // Listen for messages to persist them
-    const handleEnvelope = (envelope: SignalEnvelope) => {
+    const handleEnvelope = async (envelope: SignalEnvelope) => {
       // Determine conversation ID
       let conversationId: string | null = null;
       let newMessage: ChatMessage | null = null;
@@ -221,10 +222,19 @@ export default function App() {
       // Extract attachments from dataMessage
       if (envelope.dataMessage?.attachments && envelope.dataMessage.attachments.length > 0) {
         const signalCliDir = getSignalCliAttachmentsDir();
-        attachments = envelope.dataMessage.attachments.map(att => ({
-          ...att,
-          localPath: att.id ? join(signalCliDir, att.id) : undefined,
-          downloadStatus: "completed" as const, // signal-cli auto-downloads
+        attachments = await Promise.all(envelope.dataMessage.attachments.map(async att => {
+          const localPath = att.id ? join(signalCliDir, att.id) : undefined;
+          // Generate ASCII art for images
+          let asciiArt: string | undefined;
+          if (att.contentType?.startsWith("image/") && localPath) {
+            asciiArt = await generateAsciiArt(localPath, 40, 20);
+          }
+          return {
+            ...att,
+            localPath,
+            downloadStatus: "completed" as const,
+            asciiArt,
+          };
         }));
       }
 
@@ -257,10 +267,19 @@ export default function App() {
         const syncAttachments = (envelope.syncMessage.sentMessage as any).attachments;
         if (syncAttachments && syncAttachments.length > 0) {
           const signalCliDir = getSignalCliAttachmentsDir();
-          attachments = syncAttachments.map((att: any) => ({
-            ...att,
-            localPath: att.id ? join(signalCliDir, att.id) : undefined,
-            downloadStatus: "completed" as const,
+          attachments = await Promise.all(syncAttachments.map(async (att: any) => {
+            const localPath = att.id ? join(signalCliDir, att.id) : undefined;
+            // Generate ASCII art for images
+            let asciiArt: string | undefined;
+            if (att.contentType?.startsWith("image/") && localPath) {
+              asciiArt = await generateAsciiArt(localPath, 40, 20);
+            }
+            return {
+              ...att,
+              localPath,
+              downloadStatus: "completed" as const,
+              asciiArt,
+            };
           }));
         }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -21,6 +21,26 @@ function getSignalCliAttachmentsDir(): string {
   return join(homedir(), ".local", "share", "signal-cli", "attachments");
 }
 
+// Process attachments and generate ASCII art for images
+async function processAttachments(
+  rawAttachments: Attachment[],
+  signalCliDir: string
+): Promise<Attachment[]> {
+  return Promise.all(rawAttachments.map(async att => {
+    const localPath = att.id ? join(signalCliDir, att.id) : undefined;
+    let asciiArt: string | undefined;
+    if (att.contentType?.startsWith("image/") && localPath) {
+      asciiArt = await generateAsciiArt(localPath, 40, 20);
+    }
+    return {
+      ...att,
+      localPath,
+      downloadStatus: "completed" as const,
+      asciiArt,
+    };
+  }));
+}
+
 // Async debug logging - only active when DEBUG=true
 const DEBUG = process.env.DEBUG === "true";
 const debugLog = DEBUG
@@ -47,6 +67,10 @@ export default function App() {
 
   // Track if we're intentionally stopping (for graceful shutdown)
   const isStoppingRef = useRef(false);
+
+  // Message processing queue to ensure ordered processing of async handlers
+  const messageQueueRef = useRef<SignalEnvelope[]>([]);
+  const processingRef = useRef(false);
 
   // Cycle focus to next area
   const cycleFocus = useCallback(() => {
@@ -210,46 +234,30 @@ export default function App() {
       setErrorMessage(error.message);
     });
 
-    // Listen for messages to persist them
+    // Process a single envelope (called from queue)
     const handleEnvelope = async (envelope: SignalEnvelope) => {
-      // Determine conversation ID
       let conversationId: string | null = null;
       let newMessage: ChatMessage | null = null;
       let attachments: Attachment[] = [];
+      const signalCliDir = getSignalCliAttachmentsDir();
 
       debugLog(`[App] Received envelope: ${JSON.stringify(envelope)}`);
 
       // Extract attachments from dataMessage
       if (envelope.dataMessage?.attachments && envelope.dataMessage.attachments.length > 0) {
-        const signalCliDir = getSignalCliAttachmentsDir();
-        attachments = await Promise.all(envelope.dataMessage.attachments.map(async att => {
-          const localPath = att.id ? join(signalCliDir, att.id) : undefined;
-          // Generate ASCII art for images
-          let asciiArt: string | undefined;
-          if (att.contentType?.startsWith("image/") && localPath) {
-            asciiArt = await generateAsciiArt(localPath, 40, 20);
-          }
-          return {
-            ...att,
-            localPath,
-            downloadStatus: "completed" as const,
-            asciiArt,
-          };
-        }));
+        attachments = await processAttachments(envelope.dataMessage.attachments, signalCliDir);
       }
 
       // Check if we have a message or attachments to process
       const hasContent = envelope.dataMessage?.message || attachments.length > 0;
       const hasSyncContent = envelope.syncMessage?.sentMessage?.message ||
-        (envelope.syncMessage?.sentMessage as any)?.attachments?.length > 0;
+        (envelope.syncMessage?.sentMessage?.attachments?.length ?? 0) > 0;
 
       if (hasContent && envelope.dataMessage) {
         // Incoming Message
         if (envelope.dataMessage.groupInfo) {
-           // Group Message: Conversation ID is the GROUP ID
            conversationId = envelope.dataMessage.groupInfo.groupId;
         } else {
-           // Direct Message: Conversation ID is the SENDER
            conversationId = normalizeNumber(envelope.sourceNumber || envelope.sourceUuid);
         }
 
@@ -264,30 +272,14 @@ export default function App() {
         };
       } else if (hasSyncContent && envelope.syncMessage?.sentMessage) {
         // Outgoing Sync Message - extract attachments from sync message too
-        const syncAttachments = (envelope.syncMessage.sentMessage as any).attachments;
+        const syncAttachments = envelope.syncMessage.sentMessage.attachments;
         if (syncAttachments && syncAttachments.length > 0) {
-          const signalCliDir = getSignalCliAttachmentsDir();
-          attachments = await Promise.all(syncAttachments.map(async (att: any) => {
-            const localPath = att.id ? join(signalCliDir, att.id) : undefined;
-            // Generate ASCII art for images
-            let asciiArt: string | undefined;
-            if (att.contentType?.startsWith("image/") && localPath) {
-              asciiArt = await generateAsciiArt(localPath, 40, 20);
-            }
-            return {
-              ...att,
-              localPath,
-              downloadStatus: "completed" as const,
-              asciiArt,
-            };
-          }));
+          attachments = await processAttachments(syncAttachments, signalCliDir);
         }
 
         if (envelope.syncMessage.sentMessage.groupInfo) {
-           // Group Message: Conversation ID is the GROUP ID
            conversationId = envelope.syncMessage.sentMessage.groupInfo.groupId;
         } else {
-           // Direct Message: Conversation ID is the DESTINATION
            conversationId = normalizeNumber(envelope.syncMessage.sentMessage.destinationNumber ||
                                           envelope.syncMessage.sentMessage.destinationUuid);
         }
@@ -310,8 +302,31 @@ export default function App() {
       }
     };
 
-    signalClient.on("message", handleEnvelope);
-    signalClient.on("sync", handleEnvelope);
+    // Process messages from queue sequentially to ensure ordering
+    const processMessageQueue = async () => {
+      if (processingRef.current) return;
+      processingRef.current = true;
+
+      while (messageQueueRef.current.length > 0) {
+        const envelope = messageQueueRef.current.shift()!;
+        try {
+          await handleEnvelope(envelope);
+        } catch (error) {
+          debugLog(`[App] Error processing envelope: ${error}`);
+        }
+      }
+
+      processingRef.current = false;
+    };
+
+    // Queue incoming messages for sequential processing
+    const queueMessage = (envelope: SignalEnvelope) => {
+      messageQueueRef.current.push(envelope);
+      processMessageQueue();
+    };
+
+    signalClient.on("message", queueMessage);
+    signalClient.on("sync", queueMessage);
 
     // Listen for receipt events to update message status
     signalClient.on("receipt", (envelope: SignalEnvelope) => {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,13 +1,24 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useApp, useInput } from "ink";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import Layout from "./components/Layout.tsx";
 import { SignalClient } from "../core/SignalClient.ts";
 import { findSignalCliPath, getConfigInstructions } from "../core/Config.ts";
 import type { LinkStatus } from "./components/Onboarding.tsx";
 import type { ConnectionStatus } from "./components/StatusBar.tsx";
-import type { Account, Conversation, SignalEnvelope, ChatMessage } from "../types/types.ts";
+import type { Account, Conversation, SignalEnvelope, ChatMessage, Attachment } from "../types/types.ts";
 import { MessageStorage } from "../core/MessageStorage.ts";
 import { normalizeNumber } from "../utils/phone.ts";
+
+// Get signal-cli's attachment storage directory
+function getSignalCliAttachmentsDir(): string {
+  const xdgDataHome = process.env.XDG_DATA_HOME;
+  if (xdgDataHome) {
+    return join(xdgDataHome, "signal-cli", "attachments");
+  }
+  return join(homedir(), ".local", "share", "signal-cli", "attachments");
+}
 
 // Async debug logging - only active when DEBUG=true
 const DEBUG = process.env.DEBUG === "true";
@@ -203,10 +214,26 @@ export default function App() {
       // Determine conversation ID
       let conversationId: string | null = null;
       let newMessage: ChatMessage | null = null;
+      let attachments: Attachment[] = [];
 
       debugLog(`[App] Received envelope: ${JSON.stringify(envelope)}`);
 
-      if (envelope.dataMessage?.message) {
+      // Extract attachments from dataMessage
+      if (envelope.dataMessage?.attachments && envelope.dataMessage.attachments.length > 0) {
+        const signalCliDir = getSignalCliAttachmentsDir();
+        attachments = envelope.dataMessage.attachments.map(att => ({
+          ...att,
+          localPath: att.id ? join(signalCliDir, att.id) : undefined,
+          downloadStatus: "completed" as const, // signal-cli auto-downloads
+        }));
+      }
+
+      // Check if we have a message or attachments to process
+      const hasContent = envelope.dataMessage?.message || attachments.length > 0;
+      const hasSyncContent = envelope.syncMessage?.sentMessage?.message ||
+        (envelope.syncMessage?.sentMessage as any)?.attachments?.length > 0;
+
+      if (hasContent && envelope.dataMessage) {
         // Incoming Message
         if (envelope.dataMessage.groupInfo) {
            // Group Message: Conversation ID is the GROUP ID
@@ -215,37 +242,49 @@ export default function App() {
            // Direct Message: Conversation ID is the SENDER
            conversationId = normalizeNumber(envelope.sourceNumber || envelope.sourceUuid);
         }
-        
+
         newMessage = {
           id: envelope.timestamp.toString(),
           sender: envelope.sourceNumber || envelope.sourceUuid || "Unknown",
           senderName: envelope.sourceName,
-          content: envelope.dataMessage.message,
+          content: envelope.dataMessage.message || "",
           timestamp: envelope.timestamp,
           isOutgoing: false,
+          attachments: attachments.length > 0 ? attachments : undefined,
         };
-      } else if (envelope.syncMessage?.sentMessage?.message) {
-        // Outgoing Sync Message
+      } else if (hasSyncContent && envelope.syncMessage?.sentMessage) {
+        // Outgoing Sync Message - extract attachments from sync message too
+        const syncAttachments = (envelope.syncMessage.sentMessage as any).attachments;
+        if (syncAttachments && syncAttachments.length > 0) {
+          const signalCliDir = getSignalCliAttachmentsDir();
+          attachments = syncAttachments.map((att: any) => ({
+            ...att,
+            localPath: att.id ? join(signalCliDir, att.id) : undefined,
+            downloadStatus: "completed" as const,
+          }));
+        }
+
         if (envelope.syncMessage.sentMessage.groupInfo) {
            // Group Message: Conversation ID is the GROUP ID
            conversationId = envelope.syncMessage.sentMessage.groupInfo.groupId;
         } else {
            // Direct Message: Conversation ID is the DESTINATION
-           conversationId = normalizeNumber(envelope.syncMessage.sentMessage.destinationNumber || 
+           conversationId = normalizeNumber(envelope.syncMessage.sentMessage.destinationNumber ||
                                           envelope.syncMessage.sentMessage.destinationUuid);
         }
-        
+
         newMessage = {
           id: envelope.timestamp.toString(),
           sender: "Me",
-          content: envelope.syncMessage.sentMessage.message,
+          content: envelope.syncMessage.sentMessage.message || "",
           timestamp: envelope.timestamp,
           isOutgoing: true,
+          attachments: attachments.length > 0 ? attachments : undefined,
         };
       }
 
       if (conversationId && newMessage && storageRef.current) {
-         debugLog(`[App] Saving to DB: ${conversationId} ${newMessage.id}`);
+         debugLog(`[App] Saving to DB: ${conversationId} ${newMessage.id} attachments=${newMessage.attachments?.length || 0}`);
          storageRef.current.addMessage(newMessage, conversationId);
       } else {
          debugLog(`[App] NOT saving: conversationId=${conversationId}, hasMessage=${!!newMessage}, hasStorage=${!!storageRef.current}`);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -12,6 +12,10 @@ import { MessageStorage } from "../core/MessageStorage.ts";
 import { normalizeNumber } from "../utils/phone.ts";
 import { generateAsciiArt } from "../utils/asciiArt.ts";
 
+// ASCII art dimensions for terminal display
+export const ASCII_ART_WIDTH = 40;
+export const ASCII_ART_HEIGHT = 20;
+
 // Get signal-cli's attachment storage directory
 function getSignalCliAttachmentsDir(): string {
   const xdgDataHome = process.env.XDG_DATA_HOME;
@@ -30,7 +34,7 @@ async function processAttachments(
     const localPath = att.id ? join(signalCliDir, att.id) : undefined;
     let asciiArt: string | undefined;
     if (att.contentType?.startsWith("image/") && localPath) {
-      asciiArt = await generateAsciiArt(localPath, 40, 20);
+      asciiArt = await generateAsciiArt(localPath, ASCII_ART_WIDTH, ASCII_ART_HEIGHT);
     }
     return {
       ...att,

--- a/src/ui/components/ChatArea.tsx
+++ b/src/ui/components/ChatArea.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect, useRef, memo, useMemo, useCallback } from "react";
 import { Box, Text, useInput, useStdout } from "ink";
+import { existsSync } from "node:fs";
+import { basename } from "node:path";
 import { SignalClient } from "../../core/SignalClient.ts";
+import { getMimeType } from "../../utils/mime.ts";
 import type { Conversation, Account, ChatMessage, SignalEnvelope, Attachment } from "../../types/types.ts";
 import { MessageStorage } from "../../core/MessageStorage.ts";
 import { normalizeNumber } from "../../utils/phone.ts";
@@ -8,6 +11,123 @@ import MessageInput from "./MessageInput.tsx";
 import { theme } from "../theme.ts";
 import { formatTime } from "../../utils/formatTime.ts";
 import type { FocusArea } from "../App.tsx";
+
+// Dynamically import terminal-image (ESM module)
+let terminalImage: typeof import("terminal-image") | null = null;
+import("terminal-image").then(mod => { terminalImage = mod; }).catch(() => {});
+
+// AttachmentDisplay component for rendering images, audio, and files
+interface AttachmentDisplayProps {
+  attachment: Attachment;
+  maxWidth: number;
+}
+
+function AttachmentDisplay({ attachment, maxWidth }: AttachmentDisplayProps) {
+  const [imageOutput, setImageOutput] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Only try to render images with a valid local path
+    if (attachment.contentType.startsWith("image/") && attachment.localPath) {
+      // Check if file exists before trying to render
+      if (!existsSync(attachment.localPath)) {
+        setError("File not found");
+        return;
+      }
+
+      // Try to load and render the image
+      const loadImage = async () => {
+        try {
+          if (!terminalImage) {
+            // Module not loaded yet, wait a bit
+            await new Promise(r => setTimeout(r, 100));
+            if (!terminalImage) {
+              setError("Image rendering unavailable");
+              return;
+            }
+          }
+
+          const result = await terminalImage.default.file(attachment.localPath!, {
+            width: Math.min(maxWidth, 40),
+            preserveAspectRatio: true,
+          });
+          setImageOutput(result);
+        } catch (e) {
+          setError("Failed to load image");
+        }
+      };
+
+      loadImage();
+    }
+  }, [attachment.localPath, attachment.contentType, maxWidth]);
+
+  // Image display
+  if (attachment.contentType.startsWith("image/")) {
+    if (imageOutput) {
+      return (
+        <Box flexDirection="column">
+          <Text>{imageOutput}</Text>
+          {attachment.caption && <Text color={theme.text.muted}>{attachment.caption}</Text>}
+          {attachment.filename && <Text color={theme.text.muted} dimColor>{attachment.filename}</Text>}
+        </Box>
+      );
+    }
+    // Fallback to label while loading or on error
+    return (
+      <Box>
+        <Text color={theme.warning}>
+          [IMG] {attachment.filename || "image"}
+          {attachment.downloadStatus === "pending" && " (downloading...)"}
+          {error && ` (${error})`}
+        </Text>
+      </Box>
+    );
+  }
+
+  // Voice message / audio
+  if (attachment.contentType.startsWith("audio/")) {
+    // Rough duration estimate from file size (assuming ~16kbps for voice)
+    const duration = attachment.size ? `~${Math.round(attachment.size / 2000)}s` : "";
+    return (
+      <Box>
+        <Text color={theme.secondary}>
+          [VOICE] {duration} {attachment.filename || "voice message"}
+        </Text>
+        {attachment.localPath && (
+          <Text color={theme.text.muted} dimColor> {attachment.localPath}</Text>
+        )}
+      </Box>
+    );
+  }
+
+  // Video
+  if (attachment.contentType.startsWith("video/")) {
+    const sizeStr = attachment.size ? `(${Math.round(attachment.size / 1024)}KB)` : "";
+    return (
+      <Box>
+        <Text color={theme.warning}>
+          [VIDEO] {attachment.filename || "video"} {sizeStr}
+        </Text>
+        {attachment.localPath && (
+          <Text color={theme.text.muted} dimColor> {attachment.localPath}</Text>
+        )}
+      </Box>
+    );
+  }
+
+  // Generic file
+  const sizeStr = attachment.size ? `(${Math.round(attachment.size / 1024)}KB)` : "";
+  return (
+    <Box>
+      <Text color={theme.warning}>
+        [FILE] {attachment.filename || "attachment"} {sizeStr}
+      </Text>
+      {attachment.localPath && (
+        <Text color={theme.text.muted} dimColor> {attachment.localPath}</Text>
+      )}
+    </Box>
+  );
+}
 
 // Extended message type with grouping info
 interface DisplayMessage extends ChatMessage {
@@ -212,17 +332,40 @@ function ChatArea({
     }
   }, { isActive: focusArea === "chat" });
 
-  const handleSendMessage = useCallback(async (text: string) => {
+  const handleSendMessage = useCallback(async (text: string, attachments?: string[]) => {
     if (!client || !selectedConversation) return;
+
+    // Validate attachment paths exist
+    if (attachments && attachments.length > 0) {
+      for (const path of attachments) {
+        if (!existsSync(path)) {
+          // TODO: Show error to user - for now just log and skip
+          console.error(`[ChatArea] Attachment not found: ${path}`);
+          return;
+        }
+      }
+    }
+
+    // Build attachment metadata for optimistic message
+    const attachmentMeta: Attachment[] | undefined = attachments?.map(path => ({
+      contentType: getMimeType(path),
+      filename: basename(path),
+      localPath: path,
+      downloadStatus: "completed" as const,
+    }));
+
+    // Determine content for display
+    const displayContent = text || (attachments?.length ? "[Attachment]" : "");
 
     // Create optimistic message outside try block so it's accessible in catch
     const optimisticMessage: ChatMessage = {
       id: Date.now().toString(),
       sender: "Me",
-      content: text,
+      content: displayContent,
       timestamp: Date.now(),
       isOutgoing: true,
-      status: "sent"
+      status: "sent",
+      attachments: attachmentMeta,
     };
 
     try {
@@ -233,15 +376,18 @@ function ChatArea({
 
       const timestamp = await client.sendMessage(
         selectedConversation.id,
-        text,
-        selectedConversation.type === "group"
+        text || undefined,
+        {
+          isGroup: selectedConversation.type === "group",
+          attachments,
+        }
       );
 
       // Replace optimistic message with real one
       const realMessage: ChatMessage = {
         ...optimisticMessage,
         id: timestamp.toString(),
-        timestamp: timestamp
+        timestamp: timestamp,
       };
 
       if (storage) {
@@ -388,12 +534,13 @@ function ChatArea({
 
                     {/* Attachments */}
                     {msg.attachments && msg.attachments.length > 0 && (
-                      <Box flexDirection="row" gap={1}>
+                      <Box flexDirection="column" gap={0}>
                         {msg.attachments.map((att, i) => (
-                          <Text key={i} color={theme.warning}>
-                            {getAttachmentLabel(att)}
-                            {att.filename ? ` ${att.filename}` : ""}
-                          </Text>
+                          <AttachmentDisplay
+                            key={att.id || i}
+                            attachment={att}
+                            maxWidth={messageBoxWidth - 4}
+                          />
                         ))}
                       </Box>
                     )}

--- a/src/ui/components/ChatArea.tsx
+++ b/src/ui/components/ChatArea.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useRef, memo, useMemo, useCallback } from "react";
 import { Box, Text, useInput, useStdout } from "ink";
-import AsciifyImage from "ink-asciify-image";
 import { existsSync } from "node:fs";
 import { basename } from "node:path";
 import { SignalClient } from "../../core/SignalClient.ts";
 import { getMimeType } from "../../utils/mime.ts";
+import { generateAsciiArt } from "../../utils/asciiArt.ts";
 import type { Conversation, Account, ChatMessage, SignalEnvelope, Attachment } from "../../types/types.ts";
 import { MessageStorage } from "../../core/MessageStorage.ts";
 import { normalizeNumber } from "../../utils/phone.ts";
@@ -20,33 +20,19 @@ interface AttachmentDisplayProps {
 }
 
 function AttachmentDisplay({ attachment, maxWidth }: AttachmentDisplayProps) {
-  // Image display using ink-asciify-image (native Ink component)
-  if (attachment.contentType.startsWith("image/") && attachment.localPath) {
-    // Check if file exists
-    if (!existsSync(attachment.localPath)) {
+  // Image display - show stored ASCII art
+  if (attachment.contentType.startsWith("image/")) {
+    if (attachment.asciiArt) {
       return (
-        <Text color={theme.error}>
-          [IMG: File not found] {attachment.localPath}
-        </Text>
+        <Box flexDirection="column">
+          <Text>{attachment.asciiArt}</Text>
+          {attachment.caption && <Text color={theme.text.muted}>{attachment.caption}</Text>}
+          {attachment.filename && <Text color={theme.text.muted} dimColor>{attachment.filename}</Text>}
+        </Box>
       );
     }
-
-    // Calculate dimensions - keep width reasonable, estimate height from aspect ratio
-    const imageWidth = Math.min(maxWidth, 40);
-    const imageHeight = Math.round(imageWidth * 0.5); // Approximate aspect ratio
-
-    return (
-      <Box flexDirection="column">
-        <AsciifyImage
-          url={attachment.localPath}
-          width={imageWidth}
-          height={imageHeight}
-          tryCorrectAspectRatio={true}
-        />
-        {attachment.caption && <Text color={theme.text.muted}>{attachment.caption}</Text>}
-        {attachment.filename && <Text color={theme.text.muted} dimColor>{attachment.filename}</Text>}
-      </Box>
-    );
+    // Fallback for old messages without ASCII art
+    return <Text color={theme.text.muted}>[Image]</Text>;
   }
 
   // Voice message / audio
@@ -105,16 +91,28 @@ interface DisplayMessage extends ChatMessage {
 }
 
 // Estimate how many terminal rows a message will take
-function estimateMessageHeight(content: string, availableWidth: number): number {
+function estimateMessageHeight(msg: ChatMessage | DisplayMessage, availableWidth: number): number {
   // Base: 2 (borders) + 1 (header row) = 3 rows minimum
   const BASE_HEIGHT = 3;
 
   // Estimate content lines based on character count and width
   // Message box is 80% of chat area, minus padding and borders (~8 chars)
   const contentWidth = Math.max(20, availableWidth - 8);
-  const contentLines = Math.max(1, Math.ceil(content.length / contentWidth));
+  const contentLines = Math.max(1, Math.ceil((msg.content || "").length / contentWidth));
 
-  return BASE_HEIGHT + contentLines;
+  // Account for attachments
+  let attachmentHeight = 0;
+  if (msg.attachments) {
+    for (const att of msg.attachments) {
+      if (att.contentType.startsWith("image/")) {
+        attachmentHeight += 22; // Image height (20) + caption/filename
+      } else {
+        attachmentHeight += 2; // Text-based attachment
+      }
+    }
+  }
+
+  return BASE_HEIGHT + contentLines + attachmentHeight;
 }
 
 interface ChatAreaProps {
@@ -169,7 +167,7 @@ function ChatArea({
     while (startIndex >= 0 && startIndex < messages.length) {
       const msg = messages[startIndex];
       if (!msg) break;
-      const msgHeight = estimateMessageHeight(msg.content, chatAreaWidth);
+      const msgHeight = estimateMessageHeight(msg, chatAreaWidth);
       if (totalHeight + msgHeight > availableRows && startIndex < endIndex - 1) {
         startIndex++; // This message won't fit, go back one
         break;
@@ -311,13 +309,24 @@ function ChatArea({
       }
     }
 
-    // Build attachment metadata for optimistic message
-    const attachmentMeta: Attachment[] | undefined = attachments?.map(path => ({
-      contentType: getMimeType(path),
-      filename: basename(path),
-      localPath: path,
-      downloadStatus: "completed" as const,
-    }));
+    // Build attachment metadata for optimistic message (with ASCII art for images)
+    let attachmentMeta: Attachment[] | undefined;
+    if (attachments && attachments.length > 0) {
+      attachmentMeta = await Promise.all(attachments.map(async (path) => {
+        const contentType = getMimeType(path);
+        let asciiArt: string | undefined;
+        if (contentType.startsWith("image/")) {
+          asciiArt = await generateAsciiArt(path, 40, 20);
+        }
+        return {
+          contentType,
+          filename: basename(path),
+          localPath: path,
+          downloadStatus: "completed" as const,
+          asciiArt,
+        };
+      }));
+    }
 
     // Determine content for display
     const displayContent = text || (attachments?.length ? "[Attachment]" : "");
@@ -459,6 +468,7 @@ function ChatArea({
                     borderStyle="round"
                     borderColor={borderColor}
                     width={messageBoxWidth}
+                    overflow="hidden"
                   >
                     {/* Header row - only show if not consecutive */}
                     {!msg.isConsecutive && (

--- a/src/ui/components/ChatArea.tsx
+++ b/src/ui/components/ChatArea.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, memo, useMemo, useCallback } from "react";
 import { Box, Text, useInput, useStdout } from "ink";
+import AsciifyImage from "ink-asciify-image";
 import { existsSync } from "node:fs";
 import { basename } from "node:path";
 import { SignalClient } from "../../core/SignalClient.ts";
@@ -19,83 +20,31 @@ interface AttachmentDisplayProps {
 }
 
 function AttachmentDisplay({ attachment, maxWidth }: AttachmentDisplayProps) {
-  const [imageOutput, setImageOutput] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    // Only try to render images with a valid local path
-    if (!attachment.contentType.startsWith("image/") || !attachment.localPath) {
-      return;
-    }
-
-    // Check if file exists before trying to render
+  // Image display using ink-asciify-image (native Ink component)
+  if (attachment.contentType.startsWith("image/") && attachment.localPath) {
+    // Check if file exists
     if (!existsSync(attachment.localPath)) {
-      setError("File not found");
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-
-    // Load terminal-image and render
-    const loadImage = async () => {
-      try {
-        // Dynamic import each time to ensure it's loaded
-        const terminalImage = await import("terminal-image");
-
-        if (cancelled) return;
-
-        const result = await terminalImage.default.file(attachment.localPath!, {
-          width: Math.min(maxWidth, 40),
-          preserveAspectRatio: true,
-        });
-
-        if (cancelled) return;
-
-        setImageOutput(result);
-        setError(null);
-      } catch (e) {
-        if (!cancelled) {
-          setError(`Failed: ${e instanceof Error ? e.message : "unknown"}`);
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
-    loadImage();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [attachment.localPath, attachment.contentType, maxWidth]);
-
-  // Image display
-  if (attachment.contentType.startsWith("image/")) {
-    if (imageOutput) {
       return (
-        <Box flexDirection="column">
-          <Text>{imageOutput}</Text>
-          {attachment.caption && <Text color={theme.text.muted}>{attachment.caption}</Text>}
-          {attachment.filename && <Text color={theme.text.muted} dimColor>{attachment.filename}</Text>}
-        </Box>
+        <Text color={theme.error}>
+          [IMG: File not found] {attachment.localPath}
+        </Text>
       );
     }
-    // Fallback to label while loading or on error
+
+    // Calculate dimensions - keep width reasonable, estimate height from aspect ratio
+    const imageWidth = Math.min(maxWidth, 40);
+    const imageHeight = Math.round(imageWidth * 0.5); // Approximate aspect ratio
+
     return (
       <Box flexDirection="column">
-        <Text color={theme.warning}>
-          [IMG] {attachment.filename || "image"}
-          {loading && " (loading...)"}
-          {attachment.downloadStatus === "pending" && " (downloading...)"}
-          {error && ` (${error})`}
-        </Text>
-        {attachment.localPath && (
-          <Text color={theme.text.muted} dimColor>{attachment.localPath}</Text>
-        )}
+        <AsciifyImage
+          url={attachment.localPath}
+          width={imageWidth}
+          height={imageHeight}
+          tryCorrectAspectRatio={true}
+        />
+        {attachment.caption && <Text color={theme.text.muted}>{attachment.caption}</Text>}
+        {attachment.filename && <Text color={theme.text.muted} dimColor>{attachment.filename}</Text>}
       </Box>
     );
   }

--- a/src/ui/components/ChatArea.tsx
+++ b/src/ui/components/ChatArea.tsx
@@ -11,7 +11,7 @@ import { normalizeNumber } from "../../utils/phone.ts";
 import MessageInput from "./MessageInput.tsx";
 import { theme } from "../theme.ts";
 import { formatTime } from "../../utils/formatTime.ts";
-import type { FocusArea } from "../App.tsx";
+import { ASCII_ART_WIDTH, ASCII_ART_HEIGHT, type FocusArea } from "../App.tsx";
 
 // AttachmentDisplay component for rendering images, audio, and files
 interface AttachmentDisplayProps {
@@ -139,6 +139,7 @@ function ChatArea({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [scrollOffset, setScrollOffset] = useState(0);
   const [pendingG, setPendingG] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
   const { stdout } = useStdout();
 
   // Calculate available space for messages
@@ -298,12 +299,17 @@ function ChatArea({
   const handleSendMessage = useCallback(async (text: string, attachments?: string[]) => {
     if (!client || !selectedConversation) return;
 
+    // Clear any previous error
+    setSendError(null);
+
     // Validate attachment paths exist
     if (attachments && attachments.length > 0) {
       for (const path of attachments) {
         if (!existsSync(path)) {
-          // TODO: Show error to user - for now just log and skip
-          console.error(`[ChatArea] Attachment not found: ${path}`);
+          const errorMsg = `File not found: ${path}`;
+          setSendError(errorMsg);
+          // Auto-clear error after 5 seconds
+          setTimeout(() => setSendError(null), 5000);
           return;
         }
       }
@@ -316,7 +322,7 @@ function ChatArea({
         const contentType = getMimeType(path);
         let asciiArt: string | undefined;
         if (contentType.startsWith("image/")) {
-          asciiArt = await generateAsciiArt(path, 40, 20);
+          asciiArt = await generateAsciiArt(path, ASCII_ART_WIDTH, ASCII_ART_HEIGHT);
         }
         return {
           contentType,
@@ -562,9 +568,16 @@ function ChatArea({
       {/* Content */}
       {getContent()}
 
+      {/* Error display */}
+      {sendError && (
+        <Box marginTop={1}>
+          <Text color={theme.error}>{theme.symbols.error || "✗"} {sendError}</Text>
+        </Box>
+      )}
+
       {/* Input area */}
       {currentView === "chat" && selectedConversation && (
-        <Box marginTop={1}>
+        <Box marginTop={sendError ? 0 : 1}>
           <MessageInput onSend={handleSendMessage} focus={focusArea === "input"} onEscape={cycleFocus} />
         </Box>
       )}

--- a/src/ui/components/ChatArea.tsx
+++ b/src/ui/components/ChatArea.tsx
@@ -12,10 +12,6 @@ import { theme } from "../theme.ts";
 import { formatTime } from "../../utils/formatTime.ts";
 import type { FocusArea } from "../App.tsx";
 
-// Dynamically import terminal-image (ESM module)
-let terminalImage: typeof import("terminal-image") | null = null;
-import("terminal-image").then(mod => { terminalImage = mod; }).catch(() => {});
-
 // AttachmentDisplay component for rendering images, audio, and files
 interface AttachmentDisplayProps {
   attachment: Attachment;
@@ -25,40 +21,56 @@ interface AttachmentDisplayProps {
 function AttachmentDisplay({ attachment, maxWidth }: AttachmentDisplayProps) {
   const [imageOutput, setImageOutput] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     // Only try to render images with a valid local path
-    if (attachment.contentType.startsWith("image/") && attachment.localPath) {
-      // Check if file exists before trying to render
-      if (!existsSync(attachment.localPath)) {
-        setError("File not found");
-        return;
-      }
-
-      // Try to load and render the image
-      const loadImage = async () => {
-        try {
-          if (!terminalImage) {
-            // Module not loaded yet, wait a bit
-            await new Promise(r => setTimeout(r, 100));
-            if (!terminalImage) {
-              setError("Image rendering unavailable");
-              return;
-            }
-          }
-
-          const result = await terminalImage.default.file(attachment.localPath!, {
-            width: Math.min(maxWidth, 40),
-            preserveAspectRatio: true,
-          });
-          setImageOutput(result);
-        } catch (e) {
-          setError("Failed to load image");
-        }
-      };
-
-      loadImage();
+    if (!attachment.contentType.startsWith("image/") || !attachment.localPath) {
+      return;
     }
+
+    // Check if file exists before trying to render
+    if (!existsSync(attachment.localPath)) {
+      setError("File not found");
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    // Load terminal-image and render
+    const loadImage = async () => {
+      try {
+        // Dynamic import each time to ensure it's loaded
+        const terminalImage = await import("terminal-image");
+
+        if (cancelled) return;
+
+        const result = await terminalImage.default.file(attachment.localPath!, {
+          width: Math.min(maxWidth, 40),
+          preserveAspectRatio: true,
+        });
+
+        if (cancelled) return;
+
+        setImageOutput(result);
+        setError(null);
+      } catch (e) {
+        if (!cancelled) {
+          setError(`Failed: ${e instanceof Error ? e.message : "unknown"}`);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadImage();
+
+    return () => {
+      cancelled = true;
+    };
   }, [attachment.localPath, attachment.contentType, maxWidth]);
 
   // Image display
@@ -74,12 +86,16 @@ function AttachmentDisplay({ attachment, maxWidth }: AttachmentDisplayProps) {
     }
     // Fallback to label while loading or on error
     return (
-      <Box>
+      <Box flexDirection="column">
         <Text color={theme.warning}>
           [IMG] {attachment.filename || "image"}
+          {loading && " (loading...)"}
           {attachment.downloadStatus === "pending" && " (downloading...)"}
           {error && ` (${error})`}
         </Text>
+        {attachment.localPath && (
+          <Text color={theme.text.muted} dimColor>{attachment.localPath}</Text>
+        )}
       </Box>
     );
   }

--- a/src/ui/components/MessageInput.test.ts
+++ b/src/ui/components/MessageInput.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { analyzeAttachCommand, parseInput } from "./MessageInput.tsx";
+
+describe("analyzeAttachCommand", () => {
+  describe("non-attach commands", () => {
+    test("returns isAttachCommand: false for regular text", () => {
+      const result = analyzeAttachCommand("Hello world");
+      expect(result.isAttachCommand).toBe(false);
+    });
+
+    test("returns isAttachCommand: false for other slash commands", () => {
+      const result = analyzeAttachCommand("/help");
+      expect(result.isAttachCommand).toBe(false);
+    });
+
+    test("returns isAttachCommand: false for empty string", () => {
+      const result = analyzeAttachCommand("");
+      expect(result.isAttachCommand).toBe(false);
+    });
+  });
+
+  describe("partial command recognition", () => {
+    test("recognizes partial /a as attach command", () => {
+      const result = analyzeAttachCommand("/a");
+      expect(result.isAttachCommand).toBe(true);
+      expect(result.stage).toBe("command");
+    });
+
+    test("recognizes partial /att as attach command", () => {
+      const result = analyzeAttachCommand("/att");
+      expect(result.isAttachCommand).toBe(true);
+      expect(result.stage).toBe("command");
+    });
+
+    test("recognizes full /attach as attach command", () => {
+      const result = analyzeAttachCommand("/attach");
+      expect(result.isAttachCommand).toBe(true);
+      expect(result.stage).toBe("command");
+    });
+  });
+
+  describe("filepath parsing", () => {
+    test("enters filepath stage after space", () => {
+      const result = analyzeAttachCommand("/attach ");
+      expect(result.isAttachCommand).toBe(true);
+      expect(result.stage).toBe("command"); // No path yet
+      expect(result.filePath).toBe("");
+    });
+
+    test("parses unquoted file path", () => {
+      const result = analyzeAttachCommand("/attach /path/to/file.png");
+      expect(result.isAttachCommand).toBe(true);
+      expect(result.filePath).toBe("/path/to/file.png");
+      expect(result.stage).toBe("filepath");
+    });
+
+    test("parses double-quoted path with spaces", () => {
+      const result = analyzeAttachCommand('/attach "/path/with spaces/file.png"');
+      expect(result.isAttachCommand).toBe(true);
+      expect(result.filePath).toBe("/path/with spaces/file.png");
+      expect(result.stage).toBe("filepath");
+    });
+
+    test("parses single-quoted path", () => {
+      const result = analyzeAttachCommand("/attach '/path/to/file.png'");
+      expect(result.isAttachCommand).toBe(true);
+      expect(result.filePath).toBe("/path/to/file.png");
+      expect(result.stage).toBe("filepath");
+    });
+
+    test("handles unclosed quote as still typing", () => {
+      const result = analyzeAttachCommand('/attach "/path/still/typing');
+      expect(result.isAttachCommand).toBe(true);
+      expect(result.filePath).toBe("/path/still/typing");
+      // fileExists should be null when still in quotes
+      expect(result.fileExists).toBeNull();
+    });
+  });
+
+  describe("tilde expansion", () => {
+    test("expands ~ in file path", () => {
+      const result = analyzeAttachCommand("/attach ~/Documents/file.png");
+      expect(result.filePath).toBe("~/Documents/file.png");
+      expect(result.filePathExpanded).toBe(`${homedir()}/Documents/file.png`);
+    });
+
+    test("expands ~ in quoted path", () => {
+      const result = analyzeAttachCommand('/attach "~/My Documents/file.png"');
+      expect(result.filePath).toBe("~/My Documents/file.png");
+      expect(result.filePathExpanded).toBe(`${homedir()}/My Documents/file.png`);
+    });
+  });
+
+  describe("file existence checking", () => {
+    test("returns fileExists: true for existing file", () => {
+      // package.json should exist in cwd
+      const result = analyzeAttachCommand("/attach package.json");
+      expect(result.fileExists).toBe(true);
+    });
+
+    test("returns fileExists: false for non-existent file", () => {
+      const result = analyzeAttachCommand("/attach /nonexistent/file.xyz");
+      expect(result.fileExists).toBe(false);
+    });
+
+    test("returns fileExists: null when still typing (in quotes)", () => {
+      const result = analyzeAttachCommand('/attach "/still/typing');
+      expect(result.fileExists).toBeNull();
+    });
+  });
+
+  describe("message parsing", () => {
+    test("parses message after unquoted filepath", () => {
+      const result = analyzeAttachCommand("/attach /path/file.png Check this out!");
+      expect(result.filePath).toBe("/path/file.png");
+      expect(result.message).toBe("Check this out!");
+      expect(result.stage).toBe("message");
+    });
+
+    test("parses message after quoted filepath", () => {
+      const result = analyzeAttachCommand('/attach "/path/file.png" Here is the image');
+      expect(result.filePath).toBe("/path/file.png");
+      expect(result.message).toBe("Here is the image");
+      expect(result.stage).toBe("message");
+    });
+
+    test("handles empty message after space", () => {
+      const result = analyzeAttachCommand("/attach /path/file.png ");
+      expect(result.filePath).toBe("/path/file.png");
+      expect(result.message).toBe("");
+      // Still in filepath stage until message content exists
+      expect(result.stage).toBe("filepath");
+    });
+  });
+
+  describe("stage transitions", () => {
+    test("command stage for partial command", () => {
+      expect(analyzeAttachCommand("/att").stage).toBe("command");
+    });
+
+    test("filepath stage when typing path", () => {
+      expect(analyzeAttachCommand("/attach /path").stage).toBe("filepath");
+    });
+
+    test("message stage when typing message", () => {
+      expect(analyzeAttachCommand("/attach /path msg").stage).toBe("message");
+    });
+  });
+});
+
+describe("parseInput", () => {
+  describe("regular messages", () => {
+    test("returns message text for regular input", () => {
+      const result = parseInput("Hello world");
+      expect(result.message).toBe("Hello world");
+      expect(result.attachments).toBeUndefined();
+    });
+
+    test("trims whitespace from message", () => {
+      const result = parseInput("  Hello world  ");
+      expect(result.message).toBe("Hello world");
+    });
+
+    test("handles empty input", () => {
+      const result = parseInput("");
+      expect(result.message).toBe("");
+      expect(result.attachments).toBeUndefined();
+    });
+
+    test("handles other slash commands as regular text", () => {
+      const result = parseInput("/help");
+      expect(result.message).toBe("/help");
+      expect(result.attachments).toBeUndefined();
+    });
+  });
+
+  describe("/attach command parsing", () => {
+    test("parses /attach with unquoted path", () => {
+      const result = parseInput("/attach /path/to/file.png");
+      expect(result.message).toBe("");
+      expect(result.attachments).toEqual(["/path/to/file.png"]);
+    });
+
+    test("parses /attach with double-quoted path", () => {
+      const result = parseInput('/attach "/path/with spaces/file.png"');
+      expect(result.message).toBe("");
+      expect(result.attachments).toEqual(["/path/with spaces/file.png"]);
+    });
+
+    test("parses /attach with single-quoted path", () => {
+      const result = parseInput("/attach '/path/to/file.png'");
+      expect(result.message).toBe("");
+      expect(result.attachments).toEqual(["/path/to/file.png"]);
+    });
+
+    test("parses /attach with path and message (unquoted)", () => {
+      const result = parseInput("/attach /path/file.png Check this out!");
+      expect(result.message).toBe("Check this out!");
+      expect(result.attachments).toEqual(["/path/file.png"]);
+    });
+
+    test("parses /attach with quoted path and message", () => {
+      const result = parseInput('/attach "/path/file.png" Here is the image');
+      expect(result.message).toBe("Here is the image");
+      expect(result.attachments).toEqual(["/path/file.png"]);
+    });
+
+    test("handles unclosed double quote - treats rest as path", () => {
+      const result = parseInput('/attach "/path/no closing quote');
+      expect(result.attachments).toEqual(["/path/no closing quote"]);
+      expect(result.message).toBe("");
+    });
+
+    test("handles unclosed single quote - treats rest as path", () => {
+      const result = parseInput("/attach '/path/no closing quote");
+      expect(result.attachments).toEqual(["/path/no closing quote"]);
+      expect(result.message).toBe("");
+    });
+  });
+
+  describe("tilde expansion", () => {
+    test("expands ~ in unquoted path", () => {
+      const result = parseInput("/attach ~/file.png");
+      expect(result.attachments).toEqual([`${homedir()}/file.png`]);
+    });
+
+    test("expands ~ in quoted path", () => {
+      const result = parseInput('/attach "~/My Documents/file.png"');
+      expect(result.attachments).toEqual([`${homedir()}/My Documents/file.png`]);
+    });
+
+    test("expands ~ with message after path", () => {
+      const result = parseInput("/attach ~/file.png Here it is");
+      expect(result.attachments).toEqual([`${homedir()}/file.png`]);
+      expect(result.message).toBe("Here it is");
+    });
+  });
+
+  describe("edge cases", () => {
+    test("handles /attach with empty path after trim", () => {
+      // When path is empty after trim, returns empty string as attachment path
+      const result = parseInput("/attach /some/path");
+      expect(result.attachments).toEqual(["/some/path"]);
+    });
+
+    test("handles just /attach (no space)", () => {
+      // This doesn't match "/attach " pattern, returns as regular message
+      const result = parseInput("/attach");
+      expect(result.message).toBe("/attach");
+      expect(result.attachments).toBeUndefined();
+    });
+
+    test("trims message after quoted path", () => {
+      const result = parseInput('/attach "/path/file.png"   message with spaces   ');
+      expect(result.message).toBe("message with spaces");
+    });
+  });
+});

--- a/src/ui/components/MessageInput.test.ts
+++ b/src/ui/components/MessageInput.test.ts
@@ -73,8 +73,8 @@ describe("analyzeAttachCommand", () => {
       const result = analyzeAttachCommand('/attach "/path/still/typing');
       expect(result.isAttachCommand).toBe(true);
       expect(result.filePath).toBe("/path/still/typing");
-      // fileExists should be null when still in quotes
-      expect(result.fileExists).toBeNull();
+      // inQuotes should be true when quote is not closed
+      expect(result.inQuotes).toBe(true);
     });
   });
 
@@ -92,21 +92,28 @@ describe("analyzeAttachCommand", () => {
     });
   });
 
-  describe("file existence checking", () => {
-    test("returns fileExists: true for existing file", () => {
-      // package.json should exist in cwd
-      const result = analyzeAttachCommand("/attach package.json");
-      expect(result.fileExists).toBe(true);
+  describe("inQuotes detection", () => {
+    // Note: File existence checking is now debounced in the component state,
+    // not returned directly by analyzeAttachCommand
+
+    test("returns inQuotes: false for completed quoted path", () => {
+      const result = analyzeAttachCommand('/attach "/path/to/file.png"');
+      expect(result.inQuotes).toBe(false);
     });
 
-    test("returns fileExists: false for non-existent file", () => {
-      const result = analyzeAttachCommand("/attach /nonexistent/file.xyz");
-      expect(result.fileExists).toBe(false);
-    });
-
-    test("returns fileExists: null when still typing (in quotes)", () => {
+    test("returns inQuotes: true when still typing in double quotes", () => {
       const result = analyzeAttachCommand('/attach "/still/typing');
-      expect(result.fileExists).toBeNull();
+      expect(result.inQuotes).toBe(true);
+    });
+
+    test("returns inQuotes: true when still typing in single quotes", () => {
+      const result = analyzeAttachCommand("/attach '/still/typing");
+      expect(result.inQuotes).toBe(true);
+    });
+
+    test("returns inQuotes: false for unquoted path", () => {
+      const result = analyzeAttachCommand("/attach /path/to/file.png");
+      expect(result.inQuotes).toBe(false);
     });
   });
 

--- a/src/ui/components/MessageInput.tsx
+++ b/src/ui/components/MessageInput.tsx
@@ -1,28 +1,30 @@
-import { useState, memo, useRef } from "react";
+import { useState, memo, useRef, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { homedir } from "node:os";
 import { existsSync } from "node:fs";
 import { theme } from "../theme.ts";
 
-/**
- * Analyze /attach command for visual feedback
- */
-export function analyzeAttachCommand(text: string): {
+export interface AttachCommandInfo {
   isAttachCommand: boolean;
   commandPart: string;
   filePath: string;
   filePathExpanded: string;
   message: string;
-  fileExists: boolean | null; // null = not yet determined (still typing)
+  inQuotes: boolean;
   stage: "command" | "filepath" | "message";
-} {
-  const defaultResult = {
+}
+
+/**
+ * Analyze /attach command for visual feedback (without file existence check)
+ */
+export function analyzeAttachCommand(text: string): AttachCommandInfo {
+  const defaultResult: AttachCommandInfo = {
     isAttachCommand: false,
     commandPart: "",
     filePath: "",
     filePathExpanded: "",
     message: "",
-    fileExists: null,
+    inQuotes: false,
     stage: "command" as const,
   };
 
@@ -79,11 +81,6 @@ export function analyzeAttachCommand(text: string): {
     ? filePath.replace(/^~/, homedir())
     : filePath;
 
-  // Check if file exists (only if we have a non-empty path and not still typing)
-  const fileExists = filePath.length > 0 && !inQuotes
-    ? existsSync(filePathExpanded)
-    : null;
-
   const stage = message.length > 0 ? "message" : filePath.length > 0 ? "filepath" : "command";
 
   return {
@@ -92,7 +89,7 @@ export function analyzeAttachCommand(text: string): {
     filePath,
     filePathExpanded,
     message,
-    fileExists,
+    inQuotes,
     stage,
   };
 }
@@ -170,7 +167,37 @@ function MessageInput({ onSend, disabled, focus = true, onEscape }: MessageInput
   // State only for triggering re-renders
   const [, forceRender] = useState(0);
 
+  // Debounced file existence check
+  const [fileExists, setFileExists] = useState<boolean | null>(null);
+  const fileCheckTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const update = () => forceRender(n => n + 1);
+
+  // Debounce file existence check to avoid sync I/O on every keystroke
+  const attachInfo = analyzeAttachCommand(valueRef.current);
+  useEffect(() => {
+    // Clear pending timeout
+    if (fileCheckTimeoutRef.current) {
+      clearTimeout(fileCheckTimeoutRef.current);
+      fileCheckTimeoutRef.current = null;
+    }
+
+    // Only check if we have a complete path (not still typing in quotes)
+    if (attachInfo.isAttachCommand && attachInfo.filePath && !attachInfo.inQuotes) {
+      // Debounce by 150ms
+      fileCheckTimeoutRef.current = setTimeout(() => {
+        setFileExists(existsSync(attachInfo.filePathExpanded));
+      }, 150);
+    } else {
+      setFileExists(null);
+    }
+
+    return () => {
+      if (fileCheckTimeoutRef.current) {
+        clearTimeout(fileCheckTimeoutRef.current);
+      }
+    };
+  }, [attachInfo.filePathExpanded, attachInfo.inQuotes, attachInfo.isAttachCommand]);
 
   // Handle all input ourselves
   useInput((input, key) => {
@@ -286,9 +313,6 @@ function MessageInput({ onSend, disabled, focus = true, onEscape }: MessageInput
   const value = valueRef.current;
   const cursorOffset = cursorRef.current;
 
-  // Analyze for /attach command
-  const attachInfo = analyzeAttachCommand(value);
-
   const renderValue = () => {
     if (!value && !focus) {
       return <Text color={theme.text.muted}>Type a message...</Text>;
@@ -364,16 +388,16 @@ function MessageInput({ onSend, disabled, focus = true, onEscape }: MessageInput
       parts.push(<Text key="sp1"> </Text>);
 
       if (attachInfo.filePath) {
-        // File path with validation indicator
-        const pathColor = attachInfo.fileExists === true
+        // File path with validation indicator (uses debounced fileExists state)
+        const pathColor = fileExists === true
           ? theme.success
-          : attachInfo.fileExists === false
+          : fileExists === false
             ? theme.error
             : theme.warning;
 
-        const pathIndicator = attachInfo.fileExists === true
+        const pathIndicator = fileExists === true
           ? " \u2713" // checkmark
-          : attachInfo.fileExists === false
+          : fileExists === false
             ? " \u2717" // X
             : ""; // still typing
 
@@ -391,14 +415,14 @@ function MessageInput({ onSend, disabled, focus = true, onEscape }: MessageInput
           parts.push(
             <Text key="path" color={pathColor}>
               {pathBefore}<Text inverse>{pathCursor}</Text>{pathAfter}
-              <Text color={attachInfo.fileExists === true ? theme.success : attachInfo.fileExists === false ? theme.error : theme.text.muted}>{pathIndicator}</Text>
+              <Text color={fileExists === true ? theme.success : fileExists === false ? theme.error : theme.text.muted}>{pathIndicator}</Text>
             </Text>
           );
         } else {
           parts.push(
             <Text key="path" color={pathColor}>
               {attachInfo.filePath}
-              <Text color={attachInfo.fileExists === true ? theme.success : attachInfo.fileExists === false ? theme.error : theme.text.muted}>{pathIndicator}</Text>
+              <Text color={fileExists === true ? theme.success : fileExists === false ? theme.error : theme.text.muted}>{pathIndicator}</Text>
             </Text>
           );
         }
@@ -447,10 +471,10 @@ function MessageInput({ onSend, disabled, focus = true, onEscape }: MessageInput
     if (attachInfo.stage === "command" && !value.includes(" ")) {
       return <Text color={theme.text.muted}> (type file path next)</Text>;
     }
-    if (attachInfo.stage === "filepath" && attachInfo.filePath && attachInfo.fileExists === true) {
+    if (attachInfo.stage === "filepath" && attachInfo.filePath && fileExists === true) {
       return <Text color={theme.text.muted}> (press space to add caption, or Enter to send)</Text>;
     }
-    if (attachInfo.stage === "filepath" && attachInfo.filePath && attachInfo.fileExists === false) {
+    if (attachInfo.stage === "filepath" && attachInfo.filePath && fileExists === false) {
       return <Text color={theme.error}> (file not found)</Text>;
     }
     if (attachInfo.stage === "filepath" && !attachInfo.filePath) {

--- a/src/ui/components/MessageInput.tsx
+++ b/src/ui/components/MessageInput.tsx
@@ -7,7 +7,7 @@ import { theme } from "../theme.ts";
 /**
  * Analyze /attach command for visual feedback
  */
-function analyzeAttachCommand(text: string): {
+export function analyzeAttachCommand(text: string): {
   isAttachCommand: boolean;
   commandPart: string;
   filePath: string;
@@ -108,7 +108,7 @@ interface MessageInputProps {
  * Parse input for slash commands like /attach
  * @returns Parsed message and optional attachments
  */
-function parseInput(text: string): { message: string; attachments?: string[] } {
+export function parseInput(text: string): { message: string; attachments?: string[] } {
   const trimmed = text.trim();
 
   // /attach <filepath> [message]

--- a/src/ui/components/MessageInput.tsx
+++ b/src/ui/components/MessageInput.tsx
@@ -1,12 +1,72 @@
 import { useState, memo, useRef } from "react";
 import { Box, Text, useInput } from "ink";
+import { homedir } from "node:os";
 import { theme } from "../theme.ts";
 
 interface MessageInputProps {
-  onSend: (message: string) => void;
+  onSend: (message: string, attachments?: string[]) => void;
   disabled?: boolean;
   focus?: boolean;
   onEscape?: () => void;
+}
+
+/**
+ * Parse input for slash commands like /attach
+ * @returns Parsed message and optional attachments
+ */
+function parseInput(text: string): { message: string; attachments?: string[] } {
+  const trimmed = text.trim();
+
+  // /attach <filepath> [message]
+  // Supports quoted paths for spaces: /attach "/path/with spaces/file.png"
+  if (trimmed.startsWith("/attach ")) {
+    const rest = trimmed.slice(8).trim();
+
+    let filePath: string;
+    let message: string = "";
+
+    // Check for quoted path
+    if (rest.startsWith('"')) {
+      const endQuote = rest.indexOf('"', 1);
+      if (endQuote > 0) {
+        filePath = rest.slice(1, endQuote);
+        message = rest.slice(endQuote + 1).trim();
+      } else {
+        // No closing quote, treat everything as path
+        filePath = rest.slice(1);
+      }
+    } else if (rest.startsWith("'")) {
+      const endQuote = rest.indexOf("'", 1);
+      if (endQuote > 0) {
+        filePath = rest.slice(1, endQuote);
+        message = rest.slice(endQuote + 1).trim();
+      } else {
+        filePath = rest.slice(1);
+      }
+    } else {
+      // No quotes, split on first space
+      const spaceIndex = rest.indexOf(" ");
+      if (spaceIndex > 0) {
+        filePath = rest.slice(0, spaceIndex);
+        message = rest.slice(spaceIndex + 1).trim();
+      } else {
+        filePath = rest;
+      }
+    }
+
+    // Expand ~ to home directory
+    if (filePath.startsWith("~")) {
+      filePath = filePath.replace(/^~/, homedir());
+    }
+
+    return {
+      message,
+      attachments: [filePath],
+    };
+  }
+
+  // No command, regular message
+  return { message: trimmed };
 }
 
 function MessageInput({ onSend, disabled, focus = true, onEscape }: MessageInputProps) {
@@ -32,7 +92,11 @@ function MessageInput({ onSend, disabled, focus = true, onEscape }: MessageInput
     if (key.return) {
       const trimmed = valueRef.current.trim();
       if (trimmed && !disabled) {
-        onSend(trimmed);
+        const parsed = parseInput(trimmed);
+        // Only send if we have a message or attachments
+        if (parsed.message || (parsed.attachments && parsed.attachments.length > 0)) {
+          onSend(parsed.message, parsed.attachments);
+        }
         valueRef.current = "";
         cursorRef.current = 0;
         update();

--- a/src/ui/components/MessageInput.tsx
+++ b/src/ui/components/MessageInput.tsx
@@ -1,7 +1,101 @@
 import { useState, memo, useRef } from "react";
 import { Box, Text, useInput } from "ink";
 import { homedir } from "node:os";
+import { existsSync } from "node:fs";
 import { theme } from "../theme.ts";
+
+/**
+ * Analyze /attach command for visual feedback
+ */
+function analyzeAttachCommand(text: string): {
+  isAttachCommand: boolean;
+  commandPart: string;
+  filePath: string;
+  filePathExpanded: string;
+  message: string;
+  fileExists: boolean | null; // null = not yet determined (still typing)
+  stage: "command" | "filepath" | "message";
+} {
+  const defaultResult = {
+    isAttachCommand: false,
+    commandPart: "",
+    filePath: "",
+    filePathExpanded: "",
+    message: "",
+    fileExists: null,
+    stage: "command" as const,
+  };
+
+  // Check if starting to type /attach
+  if (!text.startsWith("/")) return defaultResult;
+
+  // Partial command match
+  if ("/attach".startsWith(text) || text.startsWith("/attach")) {
+    if (!text.startsWith("/attach ")) {
+      return {
+        ...defaultResult,
+        isAttachCommand: true,
+        commandPart: text,
+        stage: "command",
+      };
+    }
+  } else {
+    return defaultResult;
+  }
+
+  // Full command with space - now parsing file path
+  const rest = text.slice(8); // After "/attach "
+
+  let filePath = "";
+  let message = "";
+  let inQuotes = false;
+  let quoteChar = "";
+
+  // Parse file path (with quote support)
+  if (rest.startsWith('"') || rest.startsWith("'")) {
+    quoteChar = rest[0];
+    const endQuote = rest.indexOf(quoteChar, 1);
+    if (endQuote > 0) {
+      filePath = rest.slice(1, endQuote);
+      message = rest.slice(endQuote + 1).trimStart();
+    } else {
+      // Still in quoted path
+      filePath = rest.slice(1);
+      inQuotes = true;
+    }
+  } else {
+    // Unquoted path
+    const spaceIndex = rest.indexOf(" ");
+    if (spaceIndex > 0) {
+      filePath = rest.slice(0, spaceIndex);
+      message = rest.slice(spaceIndex + 1);
+    } else {
+      filePath = rest;
+    }
+  }
+
+  // Expand ~ for validation
+  const filePathExpanded = filePath.startsWith("~")
+    ? filePath.replace(/^~/, homedir())
+    : filePath;
+
+  // Check if file exists (only if we have a non-empty path and not still typing)
+  const fileExists = filePath.length > 0 && !inQuotes
+    ? existsSync(filePathExpanded)
+    : null;
+
+  const stage = message.length > 0 ? "message" : filePath.length > 0 ? "filepath" : "command";
+
+  return {
+    isAttachCommand: true,
+    commandPart: "/attach",
+    filePath,
+    filePathExpanded,
+    message,
+    fileExists,
+    stage,
+  };
+}
 
 interface MessageInputProps {
   onSend: (message: string, attachments?: string[]) => void;
@@ -192,12 +286,20 @@ function MessageInput({ onSend, disabled, focus = true, onEscape }: MessageInput
   const value = valueRef.current;
   const cursorOffset = cursorRef.current;
 
+  // Analyze for /attach command
+  const attachInfo = analyzeAttachCommand(value);
+
   const renderValue = () => {
     if (!value && !focus) {
       return <Text color={theme.text.muted}>Type a message...</Text>;
     }
     if (!value) {
       return <Text><Text inverse> </Text><Text color={theme.text.muted}>Type a message...</Text></Text>;
+    }
+
+    // Special rendering for /attach command
+    if (attachInfo.isAttachCommand && focus) {
+      return renderAttachCommand();
     }
 
     const before = value.slice(0, cursorOffset);
@@ -210,17 +312,169 @@ function MessageInput({ onSend, disabled, focus = true, onEscape }: MessageInput
     return <Text color={theme.text.primary}>{value}</Text>;
   };
 
+  // Render /attach command with syntax highlighting and validation
+  const renderAttachCommand = () => {
+    const parts: JSX.Element[] = [];
+    const fullCommand = "/attach";
+
+    // Handle partial command typing (e.g., "/att" shows "att" bright, "ach" very dim)
+    if (value.length <= 7 && !value.includes(" ")) {
+      // Still typing the command itself
+      const typed = value; // What user has typed
+      const suggestion = fullCommand.slice(typed.length); // Rest to autocomplete
+
+      // Handle cursor position within typed text
+      if (cursorOffset < typed.length) {
+        // Cursor is within the typed portion
+        const beforeCursor = typed.slice(0, cursorOffset);
+        const cursorChar = typed[cursorOffset] || " ";
+        const afterCursor = typed.slice(cursorOffset + 1);
+
+        parts.push(
+          <Text key="typed" color={theme.secondary} bold>
+            {beforeCursor}<Text inverse>{cursorChar}</Text>{afterCursor}
+          </Text>
+        );
+      } else {
+        // Cursor is at the end of typed text
+        parts.push(
+          <Text key="typed" color={theme.secondary} bold>{typed}</Text>
+        );
+        // Cursor appears right after typed text, before suggestion
+        parts.push(<Text key="cursor" inverse> </Text>);
+      }
+
+      // Show suggestion in very dim (after cursor)
+      if (suggestion) {
+        parts.push(
+          <Text key="suggest" color={theme.text.muted} dimColor>{suggestion}</Text>
+        );
+      }
+
+      return <Text>{parts}</Text>;
+    }
+
+    // Full command typed - show it highlighted
+    parts.push(
+      <Text key="cmd" color={theme.secondary} bold>/attach</Text>
+    );
+
+    if (value.length > 7) {
+      // Space after command
+      parts.push(<Text key="sp1"> </Text>);
+
+      if (attachInfo.filePath) {
+        // File path with validation indicator
+        const pathColor = attachInfo.fileExists === true
+          ? theme.success
+          : attachInfo.fileExists === false
+            ? theme.error
+            : theme.warning;
+
+        const pathIndicator = attachInfo.fileExists === true
+          ? " \u2713" // checkmark
+          : attachInfo.fileExists === false
+            ? " \u2717" // X
+            : ""; // still typing
+
+        // Check if cursor is within the file path portion
+        const pathStart = 8; // After "/attach "
+        const pathEnd = pathStart + attachInfo.filePath.length;
+
+        if (cursorOffset >= pathStart && cursorOffset <= pathEnd) {
+          // Cursor is in file path
+          const pathCursorPos = cursorOffset - pathStart;
+          const pathBefore = attachInfo.filePath.slice(0, pathCursorPos);
+          const pathCursor = attachInfo.filePath[pathCursorPos] || " ";
+          const pathAfter = attachInfo.filePath.slice(pathCursorPos + 1);
+
+          parts.push(
+            <Text key="path" color={pathColor}>
+              {pathBefore}<Text inverse>{pathCursor}</Text>{pathAfter}
+              <Text color={attachInfo.fileExists === true ? theme.success : attachInfo.fileExists === false ? theme.error : theme.text.muted}>{pathIndicator}</Text>
+            </Text>
+          );
+        } else {
+          parts.push(
+            <Text key="path" color={pathColor}>
+              {attachInfo.filePath}
+              <Text color={attachInfo.fileExists === true ? theme.success : attachInfo.fileExists === false ? theme.error : theme.text.muted}>{pathIndicator}</Text>
+            </Text>
+          );
+        }
+
+        // Message part (if any)
+        if (attachInfo.message || attachInfo.stage === "message") {
+          parts.push(<Text key="sp2"> </Text>);
+
+          const msgStart = 8 + attachInfo.filePath.length + 1;
+          if (cursorOffset >= msgStart) {
+            const msgCursorPos = cursorOffset - msgStart;
+            const msgBefore = attachInfo.message.slice(0, msgCursorPos);
+            const msgCursor = attachInfo.message[msgCursorPos] || " ";
+            const msgAfter = attachInfo.message.slice(msgCursorPos + 1);
+
+            parts.push(
+              <Text key="msg" color={theme.text.primary}>
+                {msgBefore}<Text inverse>{msgCursor}</Text>{msgAfter}
+              </Text>
+            );
+          } else {
+            parts.push(
+              <Text key="msg" color={theme.text.primary}>{attachInfo.message}</Text>
+            );
+          }
+        } else if (cursorOffset > pathEnd) {
+          // Cursor after path, before message
+          parts.push(<Text key="cursor" inverse> </Text>);
+        }
+      } else {
+        // No file path yet, show cursor
+        parts.push(<Text key="cursor" inverse> </Text>);
+      }
+    } else if (cursorOffset >= value.length) {
+      // Cursor at end of partial command
+      parts.push(<Text key="cursor" inverse> </Text>);
+    }
+
+    return <Text>{parts}</Text>;
+  };
+
+  // Hint text for /attach command
+  const getHint = () => {
+    if (!attachInfo.isAttachCommand || !focus) return null;
+
+    if (attachInfo.stage === "command" && !value.includes(" ")) {
+      return <Text color={theme.text.muted}> (type file path next)</Text>;
+    }
+    if (attachInfo.stage === "filepath" && attachInfo.filePath && attachInfo.fileExists === true) {
+      return <Text color={theme.text.muted}> (press space to add caption, or Enter to send)</Text>;
+    }
+    if (attachInfo.stage === "filepath" && attachInfo.filePath && attachInfo.fileExists === false) {
+      return <Text color={theme.error}> (file not found)</Text>;
+    }
+    if (attachInfo.stage === "filepath" && !attachInfo.filePath) {
+      return <Text color={theme.text.muted}> (enter file path)</Text>;
+    }
+    return null;
+  };
+
   return (
     <Box
-      borderStyle="single"
-      borderTop
-      borderBottom={false}
-      borderLeft={false}
-      borderRight={false}
-      borderColor={focus ? theme.border.focused : theme.border.unfocused}
+      flexDirection="column"
     >
-      <Text color={focus ? theme.primary : theme.text.muted}>{"\u203A"} </Text>
-      {renderValue()}
+      <Box
+        borderStyle="single"
+        borderTop
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        borderColor={focus ? theme.border.focused : theme.border.unfocused}
+      >
+        <Text color={focus ? theme.primary : theme.text.muted}>{"\u203A"} </Text>
+        {renderValue()}
+        {getHint()}
+      </Box>
     </Box>
   );
 }

--- a/src/utils/asciiArt.test.ts
+++ b/src/utils/asciiArt.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { generateAsciiArt } from "./asciiArt.ts";
+
+// Use a test image from node_modules
+const TEST_IMAGE_PATH = join(
+  process.cwd(),
+  "node_modules/exif-parser/test/test.jpg"
+);
+
+describe("generateAsciiArt", () => {
+  test("generates ASCII art from valid image file", async () => {
+    const result = await generateAsciiArt(TEST_IMAGE_PATH);
+
+    expect(result).toBeDefined();
+    expect(typeof result).toBe("string");
+    expect(result!.length).toBeGreaterThan(0);
+    // Should contain newlines (multiple rows)
+    expect(result).toContain("\n");
+  });
+
+  test("returns undefined for non-existent file", async () => {
+    const result = await generateAsciiArt("/nonexistent/path/image.jpg");
+
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined for invalid path", async () => {
+    const result = await generateAsciiArt("");
+
+    expect(result).toBeUndefined();
+  });
+
+  test("respects custom width parameter", async () => {
+    const narrow = await generateAsciiArt(TEST_IMAGE_PATH, 20, 10);
+    const wide = await generateAsciiArt(TEST_IMAGE_PATH, 60, 10);
+
+    expect(narrow).toBeDefined();
+    expect(wide).toBeDefined();
+
+    // Wider image should have longer lines on average
+    const narrowLines = narrow!.split("\n");
+    const wideLines = wide!.split("\n");
+
+    // The wide version should have longer max line length
+    const maxNarrowLength = Math.max(...narrowLines.map(l => l.length));
+    const maxWideLength = Math.max(...wideLines.map(l => l.length));
+
+    expect(maxWideLength).toBeGreaterThan(maxNarrowLength);
+  });
+
+  test("respects custom height parameter", async () => {
+    const short = await generateAsciiArt(TEST_IMAGE_PATH, 40, 10);
+    const tall = await generateAsciiArt(TEST_IMAGE_PATH, 40, 30);
+
+    expect(short).toBeDefined();
+    expect(tall).toBeDefined();
+
+    // Taller image should have more lines
+    const shortLineCount = short!.split("\n").length;
+    const tallLineCount = tall!.split("\n").length;
+
+    expect(tallLineCount).toBeGreaterThan(shortLineCount);
+  });
+
+  test("uses default dimensions (40x20) when not specified", async () => {
+    const result = await generateAsciiArt(TEST_IMAGE_PATH);
+
+    expect(result).toBeDefined();
+
+    // Default height is 20, so should have around 20 lines
+    const lineCount = result!.split("\n").length;
+    // Allow some tolerance for aspect ratio adjustments
+    expect(lineCount).toBeGreaterThan(10);
+    expect(lineCount).toBeLessThanOrEqual(25);
+  });
+
+  test("handles non-image file gracefully", async () => {
+    // Try to convert a text file (package.json)
+    const result = await generateAsciiArt(join(process.cwd(), "package.json"));
+
+    // Should return undefined or empty on error
+    expect(result === undefined || result === "").toBe(true);
+  });
+});

--- a/src/utils/asciiArt.ts
+++ b/src/utils/asciiArt.ts
@@ -1,0 +1,27 @@
+import { asciifyImage } from "ink-asciify-image";
+import { existsSync } from "node:fs";
+
+/**
+ * Generate ASCII art from an image file
+ * @param imagePath - Path to the image file
+ * @param width - Width in characters (default: 40)
+ * @param height - Height in rows (default: 20)
+ * @returns ASCII art as a single string with newlines, or undefined if failed
+ */
+export async function generateAsciiArt(
+  imagePath: string,
+  width: number = 40,
+  height: number = 20
+): Promise<string | undefined> {
+  try {
+    if (!existsSync(imagePath)) {
+      return undefined;
+    }
+
+    const lines = await asciifyImage(imagePath, { width, height });
+    return lines.join("\n");
+  } catch (error) {
+    // Image conversion failed - return undefined
+    return undefined;
+  }
+}

--- a/src/utils/asciiArt.ts
+++ b/src/utils/asciiArt.ts
@@ -1,6 +1,8 @@
 import { asciifyImage } from "ink-asciify-image";
 import { existsSync } from "node:fs";
 
+const DEBUG = process.env.DEBUG === "true";
+
 /**
  * Generate ASCII art from an image file
  * @param imagePath - Path to the image file
@@ -15,13 +17,18 @@ export async function generateAsciiArt(
 ): Promise<string | undefined> {
   try {
     if (!existsSync(imagePath)) {
+      if (DEBUG) {
+        console.error(`[asciiArt] File not found: ${imagePath}`);
+      }
       return undefined;
     }
 
     const lines = await asciifyImage(imagePath, { width, height });
     return lines.join("\n");
   } catch (error) {
-    // Image conversion failed - return undefined
+    if (DEBUG) {
+      console.error(`[asciiArt] Failed to convert image: ${imagePath}`, error);
+    }
     return undefined;
   }
 }

--- a/src/utils/mime.test.ts
+++ b/src/utils/mime.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test } from "bun:test";
+import { getMimeType, isImage, isAudio, isVideo } from "./mime.ts";
+
+describe("getMimeType", () => {
+  // Image formats
+  test("returns correct MIME type for .jpg", () => {
+    expect(getMimeType("photo.jpg")).toBe("image/jpeg");
+  });
+
+  test("returns correct MIME type for .jpeg", () => {
+    expect(getMimeType("photo.jpeg")).toBe("image/jpeg");
+  });
+
+  test("returns correct MIME type for .png", () => {
+    expect(getMimeType("image.png")).toBe("image/png");
+  });
+
+  test("returns correct MIME type for .gif", () => {
+    expect(getMimeType("animation.gif")).toBe("image/gif");
+  });
+
+  test("returns correct MIME type for .webp", () => {
+    expect(getMimeType("photo.webp")).toBe("image/webp");
+  });
+
+  test("returns correct MIME type for .bmp", () => {
+    expect(getMimeType("image.bmp")).toBe("image/bmp");
+  });
+
+  test("returns correct MIME type for .svg", () => {
+    expect(getMimeType("icon.svg")).toBe("image/svg+xml");
+  });
+
+  test("returns correct MIME type for .ico", () => {
+    expect(getMimeType("favicon.ico")).toBe("image/x-icon");
+  });
+
+  test("returns correct MIME type for .heic", () => {
+    expect(getMimeType("photo.heic")).toBe("image/heic");
+  });
+
+  test("returns correct MIME type for .heif", () => {
+    expect(getMimeType("photo.heif")).toBe("image/heif");
+  });
+
+  // Audio formats
+  test("returns correct MIME type for .mp3", () => {
+    expect(getMimeType("song.mp3")).toBe("audio/mpeg");
+  });
+
+  test("returns correct MIME type for .aac", () => {
+    expect(getMimeType("audio.aac")).toBe("audio/aac");
+  });
+
+  test("returns correct MIME type for .m4a", () => {
+    expect(getMimeType("voice.m4a")).toBe("audio/mp4");
+  });
+
+  test("returns correct MIME type for .ogg", () => {
+    expect(getMimeType("audio.ogg")).toBe("audio/ogg");
+  });
+
+  test("returns correct MIME type for .wav", () => {
+    expect(getMimeType("sound.wav")).toBe("audio/wav");
+  });
+
+  test("returns correct MIME type for .flac", () => {
+    expect(getMimeType("music.flac")).toBe("audio/flac");
+  });
+
+  test("returns correct MIME type for .opus", () => {
+    expect(getMimeType("voice.opus")).toBe("audio/opus");
+  });
+
+  // Video formats
+  test("returns correct MIME type for .mp4", () => {
+    expect(getMimeType("video.mp4")).toBe("video/mp4");
+  });
+
+  test("returns correct MIME type for .webm", () => {
+    expect(getMimeType("video.webm")).toBe("video/webm");
+  });
+
+  test("returns correct MIME type for .mov", () => {
+    expect(getMimeType("video.mov")).toBe("video/quicktime");
+  });
+
+  test("returns correct MIME type for .avi", () => {
+    expect(getMimeType("video.avi")).toBe("video/x-msvideo");
+  });
+
+  test("returns correct MIME type for .mkv", () => {
+    expect(getMimeType("video.mkv")).toBe("video/x-matroska");
+  });
+
+  // Document formats
+  test("returns correct MIME type for .pdf", () => {
+    expect(getMimeType("document.pdf")).toBe("application/pdf");
+  });
+
+  test("returns correct MIME type for .doc", () => {
+    expect(getMimeType("document.doc")).toBe("application/msword");
+  });
+
+  test("returns correct MIME type for .docx", () => {
+    expect(getMimeType("document.docx")).toBe(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    );
+  });
+
+  test("returns correct MIME type for .xls", () => {
+    expect(getMimeType("spreadsheet.xls")).toBe("application/vnd.ms-excel");
+  });
+
+  test("returns correct MIME type for .xlsx", () => {
+    expect(getMimeType("spreadsheet.xlsx")).toBe(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    );
+  });
+
+  test("returns correct MIME type for .ppt", () => {
+    expect(getMimeType("presentation.ppt")).toBe("application/vnd.ms-powerpoint");
+  });
+
+  test("returns correct MIME type for .pptx", () => {
+    expect(getMimeType("presentation.pptx")).toBe(
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    );
+  });
+
+  // Text formats
+  test("returns correct MIME type for .txt", () => {
+    expect(getMimeType("readme.txt")).toBe("text/plain");
+  });
+
+  test("returns correct MIME type for .csv", () => {
+    expect(getMimeType("data.csv")).toBe("text/csv");
+  });
+
+  test("returns correct MIME type for .json", () => {
+    expect(getMimeType("config.json")).toBe("application/json");
+  });
+
+  test("returns correct MIME type for .xml", () => {
+    expect(getMimeType("data.xml")).toBe("application/xml");
+  });
+
+  test("returns correct MIME type for .html", () => {
+    expect(getMimeType("page.html")).toBe("text/html");
+  });
+
+  test("returns correct MIME type for .md", () => {
+    expect(getMimeType("readme.md")).toBe("text/markdown");
+  });
+
+  // Archive formats
+  test("returns correct MIME type for .zip", () => {
+    expect(getMimeType("archive.zip")).toBe("application/zip");
+  });
+
+  test("returns correct MIME type for .gz", () => {
+    expect(getMimeType("file.gz")).toBe("application/gzip");
+  });
+
+  test("returns correct MIME type for .tar", () => {
+    expect(getMimeType("archive.tar")).toBe("application/x-tar");
+  });
+
+  test("returns correct MIME type for .rar", () => {
+    expect(getMimeType("archive.rar")).toBe("application/vnd.rar");
+  });
+
+  test("returns correct MIME type for .7z", () => {
+    expect(getMimeType("archive.7z")).toBe("application/x-7z-compressed");
+  });
+
+  // Edge cases
+  test("returns application/octet-stream for unknown extension", () => {
+    expect(getMimeType("file.xyz")).toBe("application/octet-stream");
+  });
+
+  test("returns application/octet-stream for no extension", () => {
+    expect(getMimeType("filename")).toBe("application/octet-stream");
+  });
+
+  test("handles uppercase extensions (case insensitive)", () => {
+    expect(getMimeType("PHOTO.JPG")).toBe("image/jpeg");
+  });
+
+  test("handles mixed case extensions", () => {
+    expect(getMimeType("photo.Png")).toBe("image/png");
+  });
+
+  test("handles full paths", () => {
+    expect(getMimeType("/path/to/file/photo.jpg")).toBe("image/jpeg");
+  });
+
+  test("handles paths with multiple dots", () => {
+    expect(getMimeType("file.backup.2024.png")).toBe("image/png");
+  });
+});
+
+describe("isImage", () => {
+  test("returns true for image files", () => {
+    expect(isImage("photo.jpg")).toBe(true);
+    expect(isImage("image.png")).toBe(true);
+    expect(isImage("animation.gif")).toBe(true);
+    expect(isImage("photo.webp")).toBe(true);
+    expect(isImage("icon.svg")).toBe(true);
+  });
+
+  test("returns false for non-image files", () => {
+    expect(isImage("song.mp3")).toBe(false);
+    expect(isImage("video.mp4")).toBe(false);
+    expect(isImage("document.pdf")).toBe(false);
+    expect(isImage("archive.zip")).toBe(false);
+    expect(isImage("file.txt")).toBe(false);
+  });
+
+  test("returns false for unknown extensions", () => {
+    expect(isImage("file.xyz")).toBe(false);
+  });
+});
+
+describe("isAudio", () => {
+  test("returns true for audio files", () => {
+    expect(isAudio("song.mp3")).toBe(true);
+    expect(isAudio("audio.aac")).toBe(true);
+    expect(isAudio("voice.m4a")).toBe(true);
+    expect(isAudio("sound.wav")).toBe(true);
+    expect(isAudio("music.flac")).toBe(true);
+    expect(isAudio("voice.opus")).toBe(true);
+  });
+
+  test("returns false for non-audio files", () => {
+    expect(isAudio("photo.jpg")).toBe(false);
+    expect(isAudio("video.mp4")).toBe(false);
+    expect(isAudio("document.pdf")).toBe(false);
+    expect(isAudio("archive.zip")).toBe(false);
+  });
+
+  test("returns false for unknown extensions", () => {
+    expect(isAudio("file.xyz")).toBe(false);
+  });
+});
+
+describe("isVideo", () => {
+  test("returns true for video files", () => {
+    expect(isVideo("movie.mp4")).toBe(true);
+    expect(isVideo("clip.webm")).toBe(true);
+    expect(isVideo("recording.mov")).toBe(true);
+    expect(isVideo("video.avi")).toBe(true);
+    expect(isVideo("film.mkv")).toBe(true);
+  });
+
+  test("returns false for non-video files", () => {
+    expect(isVideo("photo.jpg")).toBe(false);
+    expect(isVideo("song.mp3")).toBe(false);
+    expect(isVideo("document.pdf")).toBe(false);
+    expect(isVideo("archive.zip")).toBe(false);
+  });
+
+  test("returns false for unknown extensions", () => {
+    expect(isVideo("file.xyz")).toBe(false);
+  });
+});

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -1,0 +1,89 @@
+import { extname } from "node:path";
+
+/**
+ * Common MIME types for file extensions
+ */
+const MIME_TYPES: Record<string, string> = {
+  // Images
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".bmp": "image/bmp",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".heic": "image/heic",
+  ".heif": "image/heif",
+
+  // Audio
+  ".mp3": "audio/mpeg",
+  ".aac": "audio/aac",
+  ".m4a": "audio/mp4",
+  ".ogg": "audio/ogg",
+  ".wav": "audio/wav",
+  ".flac": "audio/flac",
+  ".opus": "audio/opus",
+
+  // Video
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".avi": "video/x-msvideo",
+  ".mkv": "video/x-matroska",
+
+  // Documents
+  ".pdf": "application/pdf",
+  ".doc": "application/msword",
+  ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".ppt": "application/vnd.ms-powerpoint",
+  ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+
+  // Text
+  ".txt": "text/plain",
+  ".csv": "text/csv",
+  ".json": "application/json",
+  ".xml": "application/xml",
+  ".html": "text/html",
+  ".md": "text/markdown",
+
+  // Archives
+  ".zip": "application/zip",
+  ".gz": "application/gzip",
+  ".tar": "application/x-tar",
+  ".rar": "application/vnd.rar",
+  ".7z": "application/x-7z-compressed",
+};
+
+/**
+ * Get MIME type from file path based on extension
+ * @param filePath - Path to the file
+ * @returns MIME type string, defaults to application/octet-stream for unknown types
+ */
+export function getMimeType(filePath: string): string {
+  const ext = extname(filePath).toLowerCase();
+  return MIME_TYPES[ext] || "application/octet-stream";
+}
+
+/**
+ * Check if a file is an image based on its MIME type
+ */
+export function isImage(filePath: string): boolean {
+  return getMimeType(filePath).startsWith("image/");
+}
+
+/**
+ * Check if a file is audio based on its MIME type
+ */
+export function isAudio(filePath: string): boolean {
+  return getMimeType(filePath).startsWith("audio/");
+}
+
+/**
+ * Check if a file is video based on its MIME type
+ */
+export function isVideo(filePath: string): boolean {
+  return getMimeType(filePath).startsWith("video/");
+}


### PR DESCRIPTION
## Summary

- **Media attachment support**: Send and receive images, voice messages, and files via `/attach` command
- **ASCII art rendering**: Display images as ASCII art in the terminal with pre-generation and database caching
- **UI/UX overhaul**: New theme system, status bar, keybind bar, and improved sidebar/chat layout
- **Visual feedback**: Real-time validation for `/attach` command with file existence checking and syntax highlighting
- **Comprehensive test coverage**: 181 tests covering MIME detection, ASCII art generation, input parsing, and attachment storage

## Changes

### New Features
- `/attach <filepath> [message]` command with quoted path support and tilde expansion
- Image-to-ASCII conversion using ink-asciify-image
- Attachment persistence in SQLite with status tracking
- Theme system with consistent color palette
- Status bar showing connection state and current conversation
- Keybind bar for quick reference

### Technical
- Extended MessageStorage with attachments table and `updateAttachmentStatus()`
- Added MIME type detection utilities (`getMimeType`, `isImage`, `isAudio`, `isVideo`)
- Modified SignalClient to support sending attachments

## Test plan

- [x] All 181 tests passing (`bun test`)
- [ ] Manual test: Send image with `/attach /path/to/image.png`
- [ ] Manual test: Send image with caption `/attach ~/photo.jpg Check this out!`
- [ ] Manual test: Receive image and verify ASCII art display
- [ ] Manual test: Verify file existence validation in input

🤖 Generated with [Claude Code](https://claude.com/claude-code)